### PR TITLE
⚡️ Integrate analyzers

### DIFF
--- a/Murder.sln
+++ b/Murder.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bang.Generator", "bang\src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Bang", "bang\src\Bang\Bang.csproj", "{5BB42532-EB96-40A7-9601-E538CBAB31FD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bang.Analyzers", "bang\src\Bang.Analyzers\Bang.Analyzers.csproj", "{C026EFCE-667C-49A5-A159-34F260EE2C71}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{5BB42532-EB96-40A7-9601-E538CBAB31FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5BB42532-EB96-40A7-9601-E538CBAB31FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5BB42532-EB96-40A7-9601-E538CBAB31FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C026EFCE-667C-49A5-A159-34F260EE2C71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C026EFCE-667C-49A5-A159-34F260EE2C71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C026EFCE-667C-49A5-A159-34F260EE2C71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C026EFCE-667C-49A5-A159-34F260EE2C71}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Murder/Components/Dialogs/RuleWatcherComponent.cs
+++ b/src/Murder/Components/Dialogs/RuleWatcherComponent.cs
@@ -12,7 +12,7 @@ namespace Murder.Components
     [Unique]
     [RuntimeOnly]
     [DoNotPersistEntityOnSave]
-    public struct RuleWatcherComponent : IModifiableComponent
+    public readonly struct RuleWatcherComponent : IModifiableComponent
     {
         public void Subscribe(Action notification)
         {

--- a/src/Murder/Components/Dialogs/StateWatcherComponent.cs
+++ b/src/Murder/Components/Dialogs/StateWatcherComponent.cs
@@ -12,7 +12,7 @@ namespace Murder.Components
     [Unique]
     [RuntimeOnly]
     [DoNotPersistEntityOnSave]
-    public struct StateWatcherComponent : IModifiableComponent
+    public readonly struct StateWatcherComponent : IModifiableComponent
     {
         public void Subscribe(Action notification)
         {

--- a/src/Murder/Components/Effects/GlobalShaderComponent.cs
+++ b/src/Murder/Components/Effects/GlobalShaderComponent.cs
@@ -3,10 +3,10 @@ using Murder.Attributes;
 
 namespace Murder.Components
 {
-    public struct GlobalShaderComponent : IComponent
+    public readonly struct GlobalShaderComponent : IComponent
     {
         [Slider]
-        public float DitherAmount = 0.9518f;
+        public readonly float DitherAmount = 0.9518f;
 
         public GlobalShaderComponent() { }
     }

--- a/src/Murder/Components/Effects/RotateComponent.cs
+++ b/src/Murder/Components/Effects/RotateComponent.cs
@@ -2,7 +2,7 @@
 
 namespace Murder.Components
 {
-    public class RotateComponent : IComponent
+    public readonly struct RotateComponent : IComponent
     {
         /// <summary>
         /// In radians.

--- a/src/Murder/Components/Graphics/FlashSpriteComponent.cs
+++ b/src/Murder/Components/Graphics/FlashSpriteComponent.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 
 namespace Murder.Components
 {
-    public struct FlashSpriteComponent: IComponent
+    public readonly struct FlashSpriteComponent: IComponent
     {
-        public float DestroyAtTime;
+        public readonly float DestroyAtTime;
 
         public FlashSpriteComponent(float destroyTimer)
         {

--- a/src/Murder/Components/Grid/RoomComponent.cs
+++ b/src/Murder/Components/Grid/RoomComponent.cs
@@ -8,7 +8,7 @@ namespace Murder.Components
     /// This describes a room component properties.
     /// </summary>
     [Requires(typeof(TileGridComponent))]
-    public struct RoomComponent : IComponent
+    public readonly struct RoomComponent : IComponent
     {
         [GameAssetId(typeof(FloorAsset))]
         public readonly Guid Floor = Guid.Empty;

--- a/src/Murder/Components/Grid/TileGridComponent.cs
+++ b/src/Murder/Components/Grid/TileGridComponent.cs
@@ -9,7 +9,7 @@ namespace Murder.Components
     /// This is a struct that points to a singleton class.
     /// Reactive systems won't be able to subscribe to this component.
     /// </summary>
-    public struct TileGridComponent : IModifiableComponent
+    public readonly struct TileGridComponent : IModifiableComponent
     {
         public readonly TileGrid Grid;
 

--- a/src/Murder/Components/InteractionComponents/InteractOnStartComponent.cs
+++ b/src/Murder/Components/InteractionComponents/InteractOnStartComponent.cs
@@ -4,5 +4,5 @@ using Murder.Utilities.Attributes;
 namespace Murder.Components
 {
     [Story]
-    public struct InteractOnStartComponent : IComponent { }
+    public readonly struct InteractOnStartComponent : IComponent { }
 }

--- a/src/Murder/Components/InteractionComponents/RemoveEntityOnRuleMatchAtLoadComponent.cs
+++ b/src/Murder/Components/InteractionComponents/RemoveEntityOnRuleMatchAtLoadComponent.cs
@@ -8,7 +8,7 @@ namespace Murder.Components
     /// This will remove the entity that contains this component as soon as the entity is serialized
     /// into an actual world instance.
     /// </summary>
-    public struct RemoveEntityOnRuleMatchAtLoadComponent : IComponent 
+    public readonly struct RemoveEntityOnRuleMatchAtLoadComponent : IComponent 
     {
         /// <summary>
         /// List of requirements which will trigger the interactive component within the same entity.

--- a/src/Murder/Components/Sound/SoundWatcherComponent.cs
+++ b/src/Murder/Components/Sound/SoundWatcherComponent.cs
@@ -12,7 +12,7 @@ namespace Murder.Components
     [Unique]
     [RuntimeOnly]
     [DoNotPersistEntityOnSave]
-    public struct SoundWatcherComponent : IModifiableComponent
+    public readonly struct SoundWatcherComponent : IModifiableComponent
     {
         public void Subscribe(Action notification)
         {

--- a/src/Murder/Components/Ui/WindowRefreshTrackerComponent.cs
+++ b/src/Murder/Components/Ui/WindowRefreshTrackerComponent.cs
@@ -10,7 +10,7 @@ namespace Murder.Components
     [Unique]
     [RuntimeOnly]
     [DoNotPersistEntityOnSave]
-    public struct WindowRefreshTrackerComponent : IModifiableComponent
+    public readonly struct WindowRefreshTrackerComponent : IModifiableComponent
     {
         public void Subscribe(Action notification)
         {

--- a/src/Murder/Messages/HighlightMessage.cs
+++ b/src/Murder/Messages/HighlightMessage.cs
@@ -2,5 +2,5 @@
 
 namespace Murder.Messages
 {
-    public struct HighlightMessage : IMessage { }
+    public readonly struct HighlightMessage : IMessage { }
 }

--- a/src/Murder/Murder.csproj
+++ b/src/Murder/Murder.csproj
@@ -33,6 +33,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\bang\src\Bang\Bang.csproj" />
     <ProjectReference Condition="'$(Configuration)' == 'Debug'" Include="..\..\bang\src\Bang.Generator\Bang.Generator.csproj" />
+    <ProjectReference Include="..\..\bang\src\Bang.Analyzers\Bang.Analyzers.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Analyzer</OutputItemType>
+    </ProjectReference>
   </ItemGroup>
 
   <!-- Generator files. This makes sure that derived projects can pull from the engine generated components. -->

--- a/src/Murder/Systems/Graphics/CameraShakeSystem.cs
+++ b/src/Murder/Systems/Graphics/CameraShakeSystem.cs
@@ -5,6 +5,7 @@ using Murder.Core.Graphics;
 
 namespace Murder.Systems;
 
+[Filter(ContextAccessorFilter.None)]
 public class CameraShakeSystem : IMonoPreRenderSystem
 {
     public CameraShakeSystem()

--- a/src/Murder/Systems/Utilities/FullscreenShortcutListener.cs
+++ b/src/Murder/Systems/Utilities/FullscreenShortcutListener.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Graphics;
 
 namespace Murder.Systems;
 
+[Filter(ContextAccessorFilter.None)]
 internal class FullscreenShortcutListener : IUpdateSystem
 {
     public void Update(Context context)


### PR DESCRIPTION
This integrates the Bang.Analyzers package in Murder. Good Stuff!

Glad it's already doing the works: There were many non-readonly structs (and even a class component!)

Now we need to talk about the other violations so you can confirm to me they are actual violations:

- All `IMessagerSystem`s have Filters that are taking Components. Is this correct? If yes, we need to change the analyzer, since it expects Messager systems to be filtered by messages and not components.
- All `IReactiveSystem`s are not using the `Filter` attribute at all. Is this correct? Right now Filter is mandatory for every system Watch is mandatory for reactive systems. If the Watch attribute is supposed to be used INSTEAD of the Filter attribute, then this needs to be changed in the analyzers as well

Also there's one proper violation in `FullscreenShortcutListener`, a system that does not act on any component 🕵️ . This is either something that needs to be changed or we can slap a  #pragma because this is a valid exception