### PR TITLE
feat: custom ignored extensions in texture packing

### DIFF
--- a/src/Murder.Editor/Assets/EditorSettingsAsset.cs
+++ b/src/Murder.Editor/Assets/EditorSettingsAsset.cs
@@ -86,6 +86,8 @@ namespace Murder.Editor.Assets
 
         public bool OnlyReloadAtlasWithChanges = true;
 
+        public string IgnoredTexturePackingExtensions = ".clip,.psd,.gitkeep";
+
         [JsonProperty]
         private ImmutableArray<(Type systemType, bool isActive)> _editorSystems = ImmutableArray<(Type systemType, bool isActive)>.Empty;
 
@@ -104,12 +106,12 @@ namespace Murder.Editor.Assets
 
         [JsonProperty, HideInEditor]
         internal float FontScale;
-        
+
         [JsonProperty]
         internal string AsepritePath = "Aseprite";
         [JsonProperty]
         internal bool SaveAsepriteInfoOnSpriteAsset = false;
-        
+
         [JsonProperty]
         [Tooltip("Path for the lua scripts relative to RawResourcesPath.")]
         internal string LuaScriptsPath = "lua";
@@ -180,7 +182,7 @@ namespace Murder.Editor.Assets
         [JsonProperty, HideInEditor]
         public (Guid Entity, IStateMachineComponent? Component)? TestStartWithEntityAndComponent;
 
-        public override void AfterDeserialized() 
+        public override void AfterDeserialized()
         {
             bool changed = false;
             for (int i = 0; i < _editorSystems.Length; ++i)

--- a/src/Murder.Editor/Data/TexturePacker.cs
+++ b/src/Murder.Editor/Data/TexturePacker.cs
@@ -258,7 +258,7 @@ namespace Murder.Editor.Data
             var ignoredExtensions = Architect.EditorSettings.IgnoredTexturePackingExtensions.Split(',');
             foreach (FileInfo fi in files)
             {
-                if (fi.Name.StartsWith("_") || ignoredExtensions.Contains(fi.Extension.ToLower()))
+                if (fi.Name.StartsWith("_") || ignoredExtensions.Contains(fi.Extension, StringComparer.InvariantCultureIgnoreCase))
                     continue;
 
                 switch (fi.Extension.ToLower())


### PR DESCRIPTION
- Adds `IgnoredTexturePackingExtensions` to the Editor settings asset so that users can specify certain file extensions they want the texture packer to ignore. 

I've been using this to allow me to create sub directories within the `resources` folder that have a `.gitkeep` file so that I can push them to github.

Also, some whitespace removal came along for the ride, I can re-submit without it if needed.