### PR TITLE
Fix directory checks in EditorDataManager

### DIFF
--- a/src/Murder.Editor/Data/EditorDataManager.cs
+++ b/src/Murder.Editor/Data/EditorDataManager.cs
@@ -193,9 +193,10 @@ namespace Murder.Editor.Data
 
         private void ScanHighResImages()
         {
-            if (!Directory.Exists(EditorSettings.RawResourcesPath))
+            string fullRawResourcesPath = FileHelper.GetPath(EditorSettings.RawResourcesPath);
+            if (!Directory.Exists(fullRawResourcesPath))
             {
-                GameLogger.Log($"Unable to find raw resources path at {FileHelper.GetPath(EditorSettings.RawResourcesPath)}. " +
+                GameLogger.Log($"Unable to find raw resources path at {FileHelper.GetPath(fullRawResourcesPath)}. " +
                     $"Use this directory for images that will be built into the atlas.");
 
                 return;


### PR DESCRIPTION

Submitting a few fixes for what I think are bugs I've run into while looking through HelloMurder.

The first fix is for an issue that I _think_ is a bug in the EditorDataManager? When selecting `Assets -> Save All Assets` in HelloMurder, _after upgrading it locally to the most recent version of Murder_, it would fail saying that the source and bin directories did not exist. After debugging a bit, I realized that only the sub directories were missing. After creating them the asset save worked as expected.

The second fix is just making sure the `ScanHighResImages` method uses a full path when checking if the directory exists, similar to how other methods in EditorDataManager_Sound.cs and EditorDataManager_Dialog.cs work.