### PR TITLE
Add exit menu & allow custom profile replacement

### DIFF
--- a/src/Murder.Editor/Data/EditorDataManager.cs
+++ b/src/Murder.Editor/Data/EditorDataManager.cs
@@ -280,7 +280,7 @@ namespace Murder.Editor.Data
             {
                 return true;
             }
-            EditorGameLogger.Warning($"The saved {GameProfileFileName} doesn't match expected base class. Expected profile class {profileType.Name} to be assignable to {typeof(GameProfile).Name} but it is not.");
+            GameLogger.Warning($"The saved {GameProfileFileName} doesn't match expected base class. Expected profile class {profileType.Name} to be assignable to {typeof(GameProfile).Name} but it is not.");
             return false;
         }
 

--- a/src/Murder.Editor/Data/EditorDataManager.cs
+++ b/src/Murder.Editor/Data/EditorDataManager.cs
@@ -257,18 +257,31 @@ namespace Murder.Editor.Data
                 _gameProfile = FileHelper.DeserializeAsset<GameProfile>(gameProfilePath)!;
             }
 
-            // Create a game profile, if none was provided from the base game or if the game
-            // provides a different one.
-            // TODO: Is there a better way to verify if the profile match?
-            GameProfile profile = CreateGameProfile();
-            if (_gameProfile is null || _gameProfile.GetType() != profile.GetType())
+            // // Create a game profile, if none was provided from the base game or if the game
+            // // provides an incompatible one.
+            if (!ValidateGameProfileType())
             {
                 GameLogger.Warning($"Didn't find {GameProfileFileName} file. Creating one.");
-
+                GameProfile profile = CreateGameProfile();
                 GameProfile = profile;
                 GameProfile.MakeGuid();
                 SaveAsset(GameProfile);
             }
+        }
+
+        private bool ValidateGameProfileType()
+        {
+            if (_gameProfile == null)
+            {
+                return false;
+            }
+            var profileType = _gameProfile.GetType();
+            if (profileType.IsAssignableTo(typeof(GameProfile)))
+            {
+                return true;
+            }
+            EditorGameLogger.Warning($"The saved {GameProfileFileName} doesn't match expected base class. Expected profile class {profileType.Name} to be assignable to {typeof(GameProfile).Name} but it is not.");
+            return false;
         }
 
         /// <summary>

--- a/src/Murder.Editor/EditorScene.cs
+++ b/src/Murder.Editor/EditorScene.cs
@@ -234,6 +234,11 @@ namespace Murder.Editor
                     ImGui.EndMenu();
                 }
 
+                if (ImGui.MenuItem("Exit", "Ctrl+Q"))
+                {
+                    Architect.Instance.QueueExitGame();
+                }
+
                 if (_showStyleEditor)
                 {
                     ImGui.Begin("Style Editor", ref _showStyleEditor,ImGuiWindowFlags.AlwaysAutoResize);


### PR DESCRIPTION
- Adds an exit menu option that allows the editor to save settings before terminating
- Updates the type validation check done to the game profile at editor startup so any type that is assignable to `GameProfile` will be correctly loaded at startup. 

I added a custom game profile to the HelloMurder project locally and it wasn't being loaded despite adding it as an asset within the editor. Adding an exit menu option so that SaveSettings can be called without running the game and updating the type validation to include any classes that are assignable to `GameProfile` allows a user to replace the default GameProfile asset by creating their custom profile in the editor and exting.