### PR TITLE
Added a number to repeated logs

### DIFF
--- a/src/Murder.Editor/Diagnostics/EditorGameLogger.cs
+++ b/src/Murder.Editor/Diagnostics/EditorGameLogger.cs
@@ -97,7 +97,7 @@ namespace Murder.Editor.Diagnostics
 
                 for (int i = 0; i < _log.Count; ++i)
                 {
-                    string msg = _log[i].Message;
+                    string msg = _log[i].Repeats <= 1 ? _log[i].Message : $"{_log[i].Message} ({_log[i].Repeats})";
 
                     ImGui.PushStyleColor(ImGuiCol.Text, _log[i].Color);
                     ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0, 0, 0));


### PR DESCRIPTION
Repeated logs/warnings/errors now show how many times they have been repeated as described in #25 .
![image](https://github.com/isadorasophia/murder/assets/70289388/7c233430-1b24-4be4-9e0a-6b774841f00d)

I also removed `_showDebug = false;` in `GameLogger.LogWarningImpl` since it closed the debug console every time a warning was printed, which doesn't seem right.

PS: This is my first PR, so I hope I didn't mess anything up. 
I've been really enjoying working with this engine.