### PR TITLE
SaveAssets uses absolute paths for directory checks

### DIFF
--- a/src/Murder.Editor/Data/EditorDataManager.cs
+++ b/src/Murder.Editor/Data/EditorDataManager.cs
@@ -450,9 +450,8 @@ namespace Murder.Editor.Data
                 return;
             }
 
-            // If the source is invalid and either the source resources or binaries path have not been initialized.
-            if (!Directory.Exists(Path.GetDirectoryName(sourcePath)) &&
-                (binPath != null && (!Directory.Exists(_sourceResourcesDirectory) || !Directory.Exists(_binResourcesDirectory))))
+            // If the source resources or binaries path have not been initialized.
+            if (!Directory.Exists(FileHelper.GetPath(_sourceResourcesDirectory)) || !Directory.Exists(FileHelper.GetPath(_binResourcesDirectory ?? "")))
             {
                 GameLogger.Error($"Unable to save asset at path {_sourceResourcesDirectory}.");
                 GameLogger.Error("Have you tried setting Game Source Path in \"Editor Profile\"?");


### PR DESCRIPTION
I've been setting up a project locally and I've not been able to save any assets in the editor. Setting a breakpoint just before the "Unable to save asset at path" error log showed that the paths for `_sourceResourceDirectory` and `_binResourcesDirectory` are relative paths and fail when run through `Directory.Exists`.

The issue seems to be caused by a few things:
- The relative paths for `_sourceResourceDirectory` and `_binResourcesDirectory` seem to be expecting a different root (see Path Issues below).
- The if check within SaveAssets is checking if the parent directory for the asset exists. If this is a new asset, that won't be true, so this check will fail in that case.

#### What did I change?
- SaveAssets no longer checks for the existence of the assets parent directory within the `resources` directory, since we'll just create it as needed later on.
- SaveAssets uses `FileHelper.GetPath` to get the absolute path to the source and bin resource directories before checking for their existence.
- I _think_ the change of always checking the existence of `_binResourcesDirectory` is ok as the directory resolves to the `bin/Debug/net7.0/resources` folder for me, which should always exists, and if it doesn't it makes sense to bail.

## Path Issues
I think the reason for why these path checks fail for me might be _how_ I'm running the editor vs the others here? I run the editor from within the `src/EditorProject` directory (`src/HelloMurder.Editor`) and that sets the WorkingDirectory to that folder. I think the editor is expecting the `WorkingDirectory` to be set to the same as `AppContext.BaseDirectory` (which is used in `FileHelper.GetPath`) which won't be the case, unless one is running the editor EXE from the build directory directly.

I think this means the `Directory.Exists` calls within EditorDataManager and elsewhere should probably be replaced with another call, perhaps to `FileHelper.ExistsFromRelativePath`?