### PR TITLE
add open folder for linux

### DIFF
--- a/src/Murder/Utilities/Serialization/FileHelper.cs
+++ b/src/Murder/Utilities/Serialization/FileHelper.cs
@@ -266,9 +266,18 @@ namespace Murder.Serialization
                         FileName = "open"
                     };
                 }
+                else if (OperatingSystem.IsLinux())
+                {
+                    startInfo = new ProcessStartInfo
+                    {
+                        FileName = $"xdg-open",
+                        Arguments = path,
+                        UseShellExecute = true,
+                    };
+                }
                 else
                 {
-                    GameLogger.Error("Open a folder in Linux has not been implemented yet (I need to test it).");
+                    GameLogger.Error($"Open a folder in {Environment.OSVersion} has not been implemented.");
                     return;
                 }
 


### PR DESCRIPTION
this pr leverages `xdg-open` to open folders under linux.

xdg-open is part of the freedesktop suite so this should catch a very reasonable amount of distros.

i tested under fedora.
