### PR TITLE
🚓 Improve error logging for invalid world

### DIFF
--- a/src/Murder.Editor/Architect.cs
+++ b/src/Murder.Editor/Architect.cs
@@ -174,18 +174,18 @@ namespace Murder.Editor
         
         internal void PlayGame(bool quickplay, Guid? startingScene = null)
         {
-            startingScene ??= Profile.StartingScene;
+            var actualStartingScene = startingScene ?? Profile.StartingScene;
 
             // Data.ResetActiveSave();
 
-            if (!quickplay && startingScene == Guid.Empty)
+            var world = actualStartingScene != Guid.Empty ? Data.TryGetAsset(actualStartingScene) as WorldAsset : null;
+            if (!quickplay && world is null)
             {
                 GameLogger.Error("Unable to start the game, please specify a valid starting scene on \"Game Profile\".");
                 return;
             }
 
-            if (Game.Data.TryGetAsset<WorldAsset>(startingScene.Value) is WorldAsset world && 
-                !world.HasSystems)
+            if (world is { HasSystems: false })
             {
                 GameLogger.Error($"Unable to start the game, '{world.Name}' has no systems. Add at least one system to the world.");
                 return;
@@ -214,7 +214,7 @@ namespace Murder.Editor
             }
             else
             {
-                _sceneLoader.SwitchScene(startingScene.Value);
+                _sceneLoader.SwitchScene(actualStartingScene);
             }
 
             if (shouldLoad)

--- a/src/Murder.Editor/Architect.cs
+++ b/src/Murder.Editor/Architect.cs
@@ -174,11 +174,11 @@ namespace Murder.Editor
         
         internal void PlayGame(bool quickplay, Guid? startingScene = null)
         {
-            var actualStartingScene = startingScene ?? Profile.StartingScene;
+            Guid actualStartingScene = startingScene ?? Profile.StartingScene;
 
             // Data.ResetActiveSave();
 
-            var world = actualStartingScene != Guid.Empty ? Data.TryGetAsset(actualStartingScene) as WorldAsset : null;
+            WorldAsset? world = actualStartingScene != Guid.Empty ? Data.TryGetAsset<WorldAsset>(actualStartingScene) : null;
             if (!quickplay && world is null)
             {
                 GameLogger.Error("Unable to start the game, please specify a valid starting scene on \"Game Profile\".");


### PR DESCRIPTION
There's a little bit of validation for checking the Game Profile's starting scene's integrity before launching a scene. If the Game Profile's starting scene does not exist (either because it was deleted or because of whatever serialization corruption), however, the editor would throw. Now it will instead show the console error message stating exactly what the problem is and how to fix it.

**Testing**

- Create a new World
- Change your starting scene to that new world
- Delete it
- Click play

The editor should not crash, but instead tell you what's wrong.