### PR TITLE
🍎 Apple-Aware shortcuts

### DIFF
--- a/src/Murder.Editor/EditorScene.cs
+++ b/src/Murder.Editor/EditorScene.cs
@@ -17,6 +17,7 @@ using Murder.Serialization;
 using Murder.Utilities;
 using System.Collections.Immutable;
 using System.Numerics;
+using System.Runtime.InteropServices;
 
 namespace Murder.Editor
 {
@@ -31,6 +32,16 @@ namespace Murder.Editor
         private Guid _selectedTab;
         private Guid _tabToSelect;
         private int _randomCrow = 0;
+
+        private static readonly Keys LeftOsActionModifier =
+            OperatingSystem.IsMacOS() ?
+                Keys.LeftWindows : /* This is equivalent to Cmd ⌘ */
+                Keys.LeftControl;
+        
+        private static readonly Keys RightOsActionModifier =
+            OperatingSystem.IsMacOS() ?
+                Keys.RightWindows : /* This is equivalent to Cmd ⌘ */
+                Keys.RightControl;
 
         private bool _isLoadingContent = true;
 
@@ -329,11 +340,12 @@ namespace Murder.Editor
                 if (_showingMetricsWindow)
                     ImGui.ShowMetricsWindow(ref _showingMetricsWindow);
 
-                if (Architect.Input.Shortcut(Keys.W, Keys.LeftControl) || Architect.Input.Shortcut(Keys.W, Keys.RightControl))
+                if (Architect.Input.Shortcut(Keys.W, LeftOsActionModifier) ||
+                    Architect.Input.Shortcut(Keys.W, RightOsActionModifier))
                 {
                     CloseTab(_selectedAssets[_selectedTab]);
                 }
-                if (Architect.Input.Shortcut(Keys.F, Keys.LeftControl) || Architect.Input.Shortcut(Keys.F, Keys.RightControl))
+                if (Architect.Input.Shortcut(Keys.F, LeftOsActionModifier) || Architect.Input.Shortcut(Keys.F, RightOsActionModifier))
                 {
                     _focusOnFind = true;
                 }

--- a/src/Murder.Editor/EditorScene_Editors.cs
+++ b/src/Murder.Editor/EditorScene_Editors.cs
@@ -142,8 +142,7 @@ namespace Murder.Editor
                 ImGui.TextColored(Microsoft.Xna.Framework.Color.DarkGray.ToSysVector4(), $"({asset.GetType().Name})");
                 ImGui.SameLine();
 
-                if (asset.CanBeSaved && (ImGui.Button("Save Asset") || Architect.Input.Shortcut(Keys.S, Keys.LeftControl) ||
-                    Architect.Input.Shortcut(Keys.S, Keys.LeftWindows)))
+                if (asset.CanBeSaved && (ImGui.Button("Save Asset") || Architect.Input.Shortcut(Keys.S, LeftOsActionModifier)))
                 {
                     customEditor?.Editor.PrepareForSaveAsset();
 
@@ -160,7 +159,7 @@ namespace Murder.Editor
                 if (asset.CanBeDeleted)
                 {
                     ImGui.SameLine();
-                    if (ImGui.Button("Delete Asset") || Architect.Input.Shortcut(Keys.Delete, Keys.LeftControl))
+                    if (ImGui.Button("Delete Asset") || Architect.Input.Shortcut(Keys.Delete, LeftOsActionModifier))
                     {
                         ImGui.OpenPopup("Delete?");
                     }
@@ -169,7 +168,7 @@ namespace Murder.Editor
                 if (asset.CanBeRenamed)
                 {
                     ImGui.SameLine();
-                    if (ImGui.Button("Rename") || Architect.Input.Shortcut(Keys.R, Keys.LeftControl))
+                    if (ImGui.Button("Rename") || Architect.Input.Shortcut(Keys.R, LeftOsActionModifier))
                     {
                         _newAssetName = asset.Name;
                         ImGui.OpenPopup("Asset Name");


### PR DESCRIPTION
This makes it so that relevant Ctrl+[Key] commands are represented as Cmd+[Key] on macOS. 

Cmd+W specifically still closes the editor, but that can only be fixed on Murder with drastic changes, so for now it won't be fixed