### PR TITLE
🔲 Add flexibility to outline rendering

### DIFF
--- a/src/Murder/Core/Graphics/DrawInfo.cs
+++ b/src/Murder/Core/Graphics/DrawInfo.cs
@@ -10,11 +10,19 @@ public enum BlendStyle
     Color
 }
 
+[Flags]
 public enum OutlineStyle
 {
-    Full,
-    Top,
-    None
+    None       = 1 << 0,
+    TopOnly    = 1 << 1,
+    RightOnly  = 1 << 2,
+    BottomOnly = 1 << 3,
+    LeftOnly   = 1 << 4,
+    Top        = TopOnly | RightOnly | LeftOnly,
+    Right      = TopOnly | BottomOnly | LeftOnly,
+    Bottom     = RightOnly | BottomOnly | LeftOnly,
+    Left       = TopOnly | BottomOnly | LeftOnly,
+    Full       = TopOnly | RightOnly | BottomOnly | LeftOnly,
 }
 
 /// <summary>

--- a/src/Murder/Services/RenderServices.cs
+++ b/src/Murder/Services/RenderServices.cs
@@ -333,14 +333,25 @@ namespace Murder.Services
 
             if (drawInfo.Outline.HasValue && drawInfo.OutlineStyle != OutlineStyle.None)
             {
-                if (drawInfo.OutlineStyle != OutlineStyle.Top)
+                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.BottomOnly))
                 {
                     drawAt(position + new Vector2(0, 1), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
                 }
 
-                drawAt(position + new Vector2(0, -1), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
-                drawAt(position + new Vector2(-1, 0), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
-                drawAt(position + new Vector2(1, 0), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
+                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.TopOnly))
+                {
+                    drawAt(position + new Vector2(0, -1), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
+                }
+
+                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.LeftOnly))
+                {
+                    drawAt(position + new Vector2(-1, 0), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
+                }
+
+                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.RightOnly))
+                {
+                    drawAt(position + new Vector2(1, 0), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
+                }
             }
 
             if (drawInfo.Shadow.HasValue)


### PR DESCRIPTION
This adds some additional options for the outline rendering. The code was already there, I just made it more configurable

The choice of names was made so as to not disrupt the existing behaviour (as in: the None/Top/Full entries of the enum all have the same behaviour as before)