### PR TITLE
🍸 Tidy up the menu bar

### DIFF
--- a/src/Murder.Editor/EditorScene_Explorer.cs
+++ b/src/Murder.Editor/EditorScene_Explorer.cs
@@ -18,21 +18,12 @@ namespace Murder.Editor
         private ExplorerWindow? _selectedExplorerWindow;
         private readonly ImmutableArray<ExplorerWindow> _explorerPages;
 
-        public EditorScene()
-        {
-            _explorerPages =
-            [
-                new("assets", "Assets", "\uf520", DrawAssetsWindow),
-                new("explorer", "Atlas", "\uf03e", DrawAtlasWindow),
-                new("save-data", "Save Data", "\uf0c7", DrawSavesWindow),
-            ];
-
-            _hoverColor = Game.Profile.Theme.HighAccent;
-            _selectedColor = Game.Profile.Theme.Accent;
-            _normalColor = Game.Profile.Theme.BgFaded;
-
-            _selectedExplorerWindow = _explorerPages.First();
-        }
+        private ImmutableArray<ExplorerWindow> CreateExplorerPages() => 
+        [
+            new("assets", "Assets", "\uf520", DrawAssetsWindow),
+            new("explorer", "Atlas", "\uf03e", DrawAtlasWindow),
+            new("save-data", "Save Data", "\uf0c7", DrawSavesWindow),
+        ];
 
         private void DrawExplorerIcons()
         {

--- a/src/Murder.Editor/EditorScene_Shortcuts.cs
+++ b/src/Murder.Editor/EditorScene_Shortcuts.cs
@@ -1,0 +1,263 @@
+﻿using ImGuiNET;
+using Microsoft.Xna.Framework.Input;
+using Murder.Assets;
+using Murder.Core.Input;
+using Murder.Diagnostics;
+using Murder.Editor.Services;
+using Murder.Editor.Utilities;
+using System.Collections.Immutable;
+
+namespace Murder.Editor;
+
+public partial class EditorScene
+{
+    private readonly ImmutableDictionary<ShortcutGroup, List<Shortcut>> _shortcuts;
+
+    private ImmutableDictionary<ShortcutGroup, List<Shortcut>> CreateShortcutList() =>
+        new Dictionary<ShortcutGroup, List<Shortcut>>
+        {
+            [ShortcutGroup.Game] =
+            [
+                new ActionShortcut("Play Game", Keys.F5, StartGame)
+            ],
+            [ShortcutGroup.View] =
+            [
+                new ActionShortcut("Game Logger", Keys.F1, ToggleGameLogger),
+                new ToggleShortcut("ImGui Demo", new Chord(Keys.G, _leftOsActionModifier, Keys.LeftShift),
+                    ToggleImGuiDemo),
+                new ToggleShortcut("Metrics", new Chord(Keys.M, _leftOsActionModifier, Keys.LeftShift),
+                    ToggleShowingMetricsWindow),
+                new ToggleShortcut("Style Editor", new Chord(Keys.E, _leftOsActionModifier, Keys.LeftShift),
+                    ToggleShowingStyleEditor)
+            ],
+            [ShortcutGroup.Assets] =
+            [
+                new ActionShortcut("Save All Assets", new Chord(Keys.S, _leftOsActionModifier, Keys.LeftShift),
+                    SaveAllAssets),
+                new ActionShortcut("Bake Aseprite Guids", new Chord(Keys.B, _leftOsActionModifier, Keys.LeftShift),
+                    BakeAsepriteGuids)
+            ],
+            [ShortcutGroup.Reload] = 
+            [
+                new ActionShortcut("Content and Atlas", Keys.F3, ReloadContentAndAtlas),
+                new ActionShortcut("Shaders", Keys.F6, ReloadShaders),
+                new ActionShortcut("Sounds", Keys.F7, ReloadSounds),
+                new ToggleShortcut(
+                    name: "Only Reload Atlas With Changes",
+                    chord: new Chord(Keys.F3, Keys.LeftShift),
+                    toggle: ReloadAtlasWithChangesToggled,
+                    defaultCheckedValue: Architect.EditorSettings.OnlyReloadAtlasWithChanges
+                )
+            ],
+            [ShortcutGroup.Tools] =
+            [
+                new ActionShortcut("Refresh Window", Keys.F4, RefreshEditorWindow),
+                new ActionShortcut("Run diagnostics", new Chord(Keys.D, _leftOsActionModifier, Keys.LeftShift),  RunDiagnostics)
+            ]
+        }.ToImmutableDictionary();
+
+    private void ToggleShowingStyleEditor(bool value)
+    {
+        _showStyleEditor = value;
+    }
+
+    private void ToggleShowingMetricsWindow(bool value)
+    {
+        _showingMetricsWindow = value;
+    }
+
+    private void ToggleImGuiDemo(bool value)
+    {
+        _showingImguiDemoWindow = value;
+    }
+
+    private void DrawMainMenuBar()
+    {
+        ImGui.BeginMainMenuBar();
+
+        foreach (ShortcutGroup group in _shortcuts.Keys)
+        {
+            // Storing this value because the keyboard shortcuts must be verified regardless.
+            var menuShouldBeDrawn = ImGui.BeginMenu(group.ToString());
+
+            foreach (Shortcut shortcut in _shortcuts[group])
+            {
+                if (Game.Input.Shortcut(shortcut.Chord))
+                {
+                    shortcut.Execute();
+                }
+
+
+                if (menuShouldBeDrawn && DrawShortcut(shortcut))
+                {
+                    shortcut.Execute();
+                }
+            }
+
+            // We only need to end a menu that was rendered.
+            if (menuShouldBeDrawn)
+            {
+                ImGui.EndMenu();
+            }
+        }
+
+        ImGui.EndMainMenuBar();
+        
+        if (Game.Input.Shortcut(Keys.Escape) && GameLogger.IsShowing)
+        {
+            ToggleGameLogger();
+        }
+        
+        // If there is no lock, the player attempted to play the game.
+        if (!_f5Lock && Game.Input.Pressed(MurderInputButtons.PlayGame))
+        {
+            Architect.Instance.QueueStartPlayingGame(quickplay: Game.Input.Pressed(Keys.LeftShift) || Game.Input.Pressed(Keys.RightShift));
+        }
+        
+        if (_f5Lock && !Game.Input.Pressed(MurderInputButtons.PlayGame))
+        {
+            _f5Lock = false;
+        }
+        
+        if (Game.Input.Shortcut(Keys.W, _leftOsActionModifier) ||
+            Game.Input.Shortcut(Keys.W, _rightOsActionModifier))
+        {
+            CloseTab(_selectedAssets[_selectedTab]);
+        }
+
+        if (Game.Input.Shortcut(Keys.F, _leftOsActionModifier) || 
+            Game.Input.Shortcut(Keys.F, _rightOsActionModifier))
+        {
+            _focusOnFind = true;
+        }
+    }
+
+    private static bool DrawShortcut(Shortcut shortcut)
+    {
+        if (shortcut is ToggleShortcut toggleShortcut)
+        {
+            return ImGui.MenuItem(shortcut.Name, shortcut.Chord.ToString(), ref toggleShortcut.Checked);
+        }
+        
+        return ImGui.MenuItem(shortcut.Name, shortcut.Chord.ToString());
+    }
+
+    private void RefreshEditorWindow()
+    {
+        Architect.Instance.SaveWindowPosition();
+        Architect.Instance.RefreshWindow();
+    }
+
+    private void RunDiagnostics()
+    {
+        if (_selectedTab == Guid.Empty || !_selectedAssets.TryGetValue(_selectedTab, out GameAsset? asset))
+        {
+            GameLogger.Warning("An asset must be opened in order to run diagnostics.");
+        }
+        else
+        {
+            CustomEditorInstance? instance = GetOrCreateAssetEditor(asset);
+            if (instance?.Editor.RunDiagnostics() ?? true)
+            {
+                GameLogger.Log($"\uf00c Successfully ran diagnostics on {asset.Name}.");
+            }
+            else
+            {
+                GameLogger.Log($"\uf00d Issue found while running diagnostics on {asset.Name}.");
+            }
+        }
+    }
+
+    private void ReloadAtlasWithChangesToggled(bool value)
+    {
+        Architect.EditorSettings.OnlyReloadAtlasWithChanges = value;
+    }
+
+    private static void ReloadContentAndAtlas()
+    {
+        _ = Architect.EditorData.ReloadSprites();
+        AssetsFilter.RefreshCache();
+    }
+
+    private static void ReloadShaders()
+    {
+        Architect.Instance.ReloadShaders();
+    }
+
+    private static void ReloadSounds()
+    {
+        _ = Game.Data.LoadSounds(reload: true);
+    }
+
+    private static void SaveAllAssets()
+    {
+        Architect.EditorData.SaveAllAssets();
+    }
+
+    private static void BakeAsepriteGuids()
+    {
+        AsepriteServices.BakeAllAsepriteFileGuid();
+    }
+
+    private void StartGame()
+    {
+        SaveEditorState();
+        Architect.Instance.QueueStartPlayingGame(false);
+    }
+
+    private static void ToggleGameLogger()
+    {
+        GameLogger.GetOrCreateInstance().ToggleDebugWindow();
+    }
+
+    private enum ShortcutGroup
+    {
+        Game,
+        Assets,
+        View,
+        Reload,
+        Tools
+    }
+
+    private abstract record Shortcut(string Name, Chord Chord)
+    {
+        public abstract void Execute();
+    }
+
+    private sealed record ActionShortcut(
+        string Name,
+        Chord Chord,
+        Action Action
+    ) : Shortcut(Name, Chord)
+    {
+        public override void Execute()
+        {
+            Action();
+        }
+    }
+    
+    private sealed record ToggleShortcut(
+        string Name,
+        Chord Chord,
+        Action<bool> Toggle
+    ) : Shortcut(Name, Chord)
+    {
+        public bool Checked;
+
+        public ToggleShortcut(
+            string name,
+            Chord chord,
+            Action<bool> toggle,
+            bool defaultCheckedValue
+        ) : this(name, chord, toggle)
+        {
+            Checked = defaultCheckedValue;
+        }
+
+        public override void Execute()
+        {
+            Checked = !Checked;
+            Toggle(Checked);
+        }
+    }
+}

--- a/src/Murder/Core/Input/Chord.cs
+++ b/src/Murder/Core/Input/Chord.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Xna.Framework.Input;
+
+namespace Murder.Core.Input;
+
+/// <summary>
+/// Represents a sequence of Key with optional modifiers.
+/// </summary>
+/// <param name="key">Key that must be pressed to trigger this chord.</param>
+/// <param name="modifiers">Optional modifiers that need to be pressed along with the key.</param>
+public sealed class Chord(Keys key, params Keys[] modifiers)
+{
+    /// <summary>
+    /// The key that needs to be pressed to trigger this chord.
+    /// </summary>
+    public Keys Key { get; } = key;
+    
+    /// <summary>
+    /// A list of optional modifiers that need to be pressed along with <see cref="Key"/> in order to trigger this chord.
+    /// </summary>
+    public Keys[] Modifiers { get; } = modifiers;
+
+    ///  <inheritdoc cref="object"/>
+    public override string ToString()
+        => Modifiers.Length > 0 ? string.Join("+", Modifiers.ToList().Append(Key).Select(PrettyKeyName)) : Key.ToString();
+
+    /// <summary>
+    /// Returns a printable name for the passed key
+    /// </summary>
+    private static string PrettyKeyName(Keys key) => key switch
+    {
+        Keys.LeftShift or Keys.RightShift => "Shift",
+        Keys.LeftControl or Keys.RightControl => "Ctrl",
+        Keys.LeftWindows or Keys.RightWindows => "Cmd",
+        _ => key.ToString()
+    };
+
+    /// <summary>
+    /// Converts a single key into a chord.
+    /// </summary>
+    /// <returns>A chord triggered by the single key without modifiers.</returns>
+    public static implicit operator Chord(Keys key) => new(key);
+}

--- a/src/Murder/Core/Input/PlayerInput.cs
+++ b/src/Murder/Core/Input/PlayerInput.cs
@@ -206,6 +206,8 @@ namespace Murder.Core.Input
             GetOrCreateButton(button).OnPress += action;
         }
 
+        public bool Shortcut(Chord chord) => Shortcut(chord.Key, chord.Modifiers);
+
         public bool Shortcut(Keys key, params Keys[] modifiers)
         {
             foreach (var k in modifiers)


### PR DESCRIPTION
This refactors the way the menu bar is laid out so that:

- All shortcuts exist in the same place
- All menu bar action need to be assigned a shortcut before they can be rendered.

On its own this already has benefits over the current approach, but the endgame is to implement a global action runner/command palette that allows users to discover all shortcuts. A dirty prototype of what I mean can be seen in the gif below.


<img src="https://cdn.discordapp.com/attachments/1151949768344490054/1194372157195702282/editor_run_action.gif?ex=65b01cc0&is=659da7c0&hm=708566f308bc726ffe4babbb1297e807876fa93de8630beee2aa7074a9ba4e64&" />