### PR TITLE
💥 Fix crash when quitting to editor

### DIFF
--- a/src/Murder.Editor/Utilities/AssetsFilter.cs
+++ b/src/Murder.Editor/Utilities/AssetsFilter.cs
@@ -180,15 +180,13 @@ namespace Murder.Editor.Utilities
 
         public static IEnumerable<Type> GetAllSystems()
         {
-            return AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(assembly => assembly.GetTypes())
+            return ReflectionHelper.SafeGetAllTypesInAllAssemblies()
                 .Where(type => type.GetInterfaces().Contains(typeof(Bang.Systems.ISystem)) && !type.IsInterface);
         }
 
         public static IEnumerable<Type> GetFromInterface(Type @interface)
         {
-            return AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(assembly => assembly.GetTypes())
+            return ReflectionHelper.SafeGetAllTypesInAllAssemblies()
                 .Where(type => type.GetInterfaces().Contains(@interface) && !type.IsInterface);
         }
 

--- a/src/Murder.Editor/Utilities/Gui/SearchBox.cs
+++ b/src/Murder.Editor/Utilities/Gui/SearchBox.cs
@@ -88,8 +88,7 @@ namespace Murder.Editor.ImGuiExtended
             string selected = "Select a shape";
 
             // Find all non-repeating components
-            IEnumerable<Type> types = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(s => s.GetTypes())
+            IEnumerable<Type> types = ReflectionHelper.SafeGetAllTypesInAllAssemblies()
                 .Where(p => !p.IsInterface && typeof(IShape).IsAssignableFrom(p));
 
             Lazy<Dictionary<string, Type>> candidates = new(CollectionHelper.ToStringDictionary(types, t => t.Name, t => t));

--- a/src/Murder.Editor/Utilities/ReflectionHelper.cs
+++ b/src/Murder.Editor/Utilities/ReflectionHelper.cs
@@ -163,7 +163,7 @@ namespace Murder.Editor.Utilities
                 ?.GetCustomAttribute<TooltipAttribute>()?.Text;
         }
 
-        private static IEnumerable<Type> SafeGetAllTypesInAllAssemblies()
+        public static IEnumerable<Type> SafeGetAllTypesInAllAssemblies()
         {
             // TODO: Can this me memoized? Probably.
             List<Type> result = [];

--- a/src/Murder.Editor/Utilities/ReflectionHelper.cs
+++ b/src/Murder.Editor/Utilities/ReflectionHelper.cs
@@ -163,24 +163,21 @@ namespace Murder.Editor.Utilities
                 ?.GetCustomAttribute<TooltipAttribute>()?.Text;
         }
 
+        private static readonly HashSet<string> IgnoredAssemblies = new() { "Bang.Generator" };
+
         public static IEnumerable<Type> SafeGetAllTypesInAllAssemblies()
         {
-            // TODO: Can this me memoized? Probably.
-            List<Type> result = [];
-
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                try
+                var assemblyName = assembly.GetName().Name;
+                if (assemblyName is not null && IgnoredAssemblies.Contains(assemblyName))
+                    continue;
+
+                foreach (Type type in assembly.GetTypes())
                 {
-                    result.AddRange(assembly.GetTypes());
-                }
-                catch (ReflectionTypeLoadException)
-                {
-                    // Can be safely ignored.
+                    yield return type;
                 }
             }
-
-            return result;
         }
     }
 }


### PR DESCRIPTION
I'm consistently getting crashes (Rider 2023.3.2, both on macOS and Windows) whenever I exit the game from the editor. This completely ruins the fast paced experience. The error I'm getting is the following:

```
Unhandled exception. System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types.
Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
Could not load file or assembly 'Microsoft.CodeAnalysis.CSharp, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.
   at System.Reflection.RuntimeModule.GetTypes(RuntimeModule module)
   at System.Reflection.RuntimeModule.GetTypes()
```

This fixes this error by safely catching the exception whenever we are doing reflection and getting all types from all assemblies.