### PR TITLE
📐 Add layout constraint system

### DIFF
--- a/src/Murder.Editor/CustomFields/ImmutableArrayConstraintField.cs
+++ b/src/Murder.Editor/CustomFields/ImmutableArrayConstraintField.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Immutable;
+using ImGuiNET;
+using Murder.Core.Ui;
+using Murder.Editor.ImGuiExtended;
+using Murder.Editor.Reflection;
+
+namespace Murder.Editor.CustomFields;
+
+[CustomFieldOf(typeof(ImmutableArray<IConstraint>))]
+internal class ConstraintArrayField : ImmutableArrayField<IConstraint>
+{
+    protected override bool Add(in EditorMember member, out IConstraint? element)
+    {
+        element = null;
+        ImGui.PushID($"Add ${member.Member.ReflectedType}");
+
+        var result = false;
+        if (SearchBox.SearchConstraints() is { } constraintType)
+        {
+            if (Activator.CreateInstance(constraintType) is IConstraint constraint)
+            {
+                element = constraint;
+                result = true;
+            }
+        }
+
+        ImGui.PopID();
+        
+        return result;
+    }
+}

--- a/src/Murder.Editor/Utilities/Gui/SearchBox.cs
+++ b/src/Murder.Editor/Utilities/Gui/SearchBox.cs
@@ -6,6 +6,7 @@ using Murder.Attributes;
 using Murder.Core.Dialogs;
 using Murder.Core.Geometry;
 using Murder.Core.Sounds;
+using Murder.Core.Ui;
 using Murder.Editor.Utilities;
 using Murder.Prefabs;
 using Murder.Utilities;
@@ -603,6 +604,20 @@ namespace Murder.Editor.ImGuiExtended
             }
 
             return modified;
+        }
+
+
+        public static Type? SearchConstraints()
+        {
+            string selected = "Select a constraint";
+
+            // Find all non-repeating components
+            IEnumerable<Type> types = ReflectionHelper.SafeGetAllTypesInAllAssemblies()
+                .Where(p => !p.IsInterface && typeof(IConstraint).IsAssignableFrom(p));
+
+            Lazy<Dictionary<string, Type>> candidates = new(CollectionHelper.ToStringDictionary(types, t => t.Name, t => t));
+
+            return Search(id: "constraint_search", hasInitialValue: false, selected, values: candidates, SearchBoxFlags.None, out Type? chosen) ? chosen : default;
         }
     }
 }

--- a/src/Murder/Core/Ui/ConstraintLayout.cs
+++ b/src/Murder/Core/Ui/ConstraintLayout.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections.Immutable;
+using Bang;
+using Bang.Entities;
+using Bang.Systems;
+using Murder.Attributes;
+using Murder.Core.Geometry;
+using Murder.Core.Graphics;
+using Murder.Core.Physics;
+using Murder.Diagnostics;
+using System.ComponentModel;
+using Point = Murder.Core.Geometry.Point;
+using Rectangle = Murder.Core.Geometry.Rectangle;
+using IComponent = Bang.Components.IComponent;
+
+namespace Murder.Core.Ui;
+
+/// <summary>
+/// Describes constraints on how an entity must be positioned on the screen.
+/// </summary>
+public interface IConstraint
+{
+    // Adding these annotations because, for now, we don't want users to override these values. 
+    // If they choose to do so, it's at their own peril.
+    /// <summary>
+    /// Order in which this constraint should be applied (lower gets applied first). 
+    /// </summary>
+    [HideInEditor, EditorBrowsable(EditorBrowsableState.Never)]
+    int Order { get; }
+
+    /// <summary>
+    /// Priority this constraint will have when laying elements down (higher overrides lower).
+    /// </summary>
+    [HideInEditor, EditorBrowsable(EditorBrowsableState.Never)]
+    int Priority { get; }
+}
+
+/// <summary>
+/// Holds the constraints necessary to render an entity on the right place.
+/// </summary>
+public readonly struct ConstraintsComponent() : IComponent
+{
+    /// <summary>
+    /// List of constraints applicable to the entity possessing this component.
+    /// </summary>
+    public readonly ImmutableArray<IConstraint> Constraints = ImmutableArray<IConstraint>.Empty;
+}
+
+/// <summary>
+/// Updates the entity's position and Box collider based on its layout constraints.
+/// </summary>
+[Watch(typeof(ConstraintsComponent))]
+public sealed class LayoutConstraintSystem : IReactiveSystem
+{
+    
+    /// <inheritdoc cref="IReactiveSystem"/>
+    public void OnAdded(World world, ImmutableArray<Entity> entities)
+    {
+        Camera2D camera = ((MonoWorld)world).Camera;
+        LayoutEntities(camera.Size, entities);
+    }
+
+    /// <inheritdoc cref="IReactiveSystem"/>
+    public void OnRemoved(World world, ImmutableArray<Entity> entities)
+    {
+    }
+
+    /// <inheritdoc cref="IReactiveSystem"/>
+    public void OnModified(World world, ImmutableArray<Entity> entities)
+    {
+        Camera2D camera = ((MonoWorld)world).Camera;
+        LayoutEntities(camera.Size, entities);
+    }
+
+    private readonly record struct ConstraintSetValue(int Value, int ConstraintPriority);
+
+    private static void LayoutEntities(Point screenDimensions, ImmutableArray<Entity> entities)
+    {
+        foreach (var entity in entities)
+        {
+            var constraints = entity
+                .GetConstraints()
+                .Constraints;
+
+            if (constraints.IsEmpty)
+            {
+                continue;
+            }
+
+            ConstraintSetValue x = new(), y = new(), width = new(), height = new();
+
+            foreach (var constraint in constraints.OrderBy(c => c.Order))
+            {
+                var constraintPriority = constraint.Priority;
+                switch (constraint)
+                {
+            }
+
+            LogWarningForUnsetProperties(entity, x, y, width, height);
+            
+            var position = new Point(x.Value, y.Value);
+            entity.SetPosition(position);
+
+            var bounds = new Rectangle(0, 0, width.Value, height.Value);
+            var shape = new BoxShape(bounds);
+            var existingCollider = entity.TryGetCollider();
+            entity.SetCollider(
+                shape,
+                existingCollider?.Layer ?? CollisionLayersBase.TRIGGER, 
+                existingCollider?.DebugColor ?? Color.Magenta
+            );
+        }
+    }
+
+    private static void LogWarningForUnsetProperties(
+        Entity entity,
+        ConstraintSetValue x,
+        ConstraintSetValue y,
+        ConstraintSetValue width,
+        ConstraintSetValue height
+    )
+    {
+        if (height.Value == 0)
+        {
+            GameLogger.Warning($"Constraints failed to calculate the height of entity with id {entity.EntityId}. Setting it to 0.");
+        }
+        if (width.Value == 0)
+        {
+            GameLogger.Warning($"Constraints failed to calculate the width of entity with id {entity.EntityId}. Setting it to 0.");
+        }
+        if (x.ConstraintPriority == 0)
+        {
+            GameLogger.Warning($"Constraints failed to calculate the x position of entity with id {entity.EntityId}. Setting it to 0.");
+        }
+        if (y.ConstraintPriority == 0)
+        {
+            GameLogger.Warning($"Constraints failed to calculate the y position of entity with id {entity.EntityId}. Setting it to 0.");
+        }
+    }
+}


### PR DESCRIPTION
This implements a pretty basic, but extensible, layout constraint system.

Right now one can snap the UI on any of the four sides of the screen, center it vertically or horizontally and also force a width or height. We can implement relative layout and other constraints on future iterations.

I'm using the `CollisionComponent` as the way of indicating the size while using a `PositionComponent` to indicate where on the screen the UI will be rendered. Do let me know if there are better candidates for either.

Needless to say, this assumes the target batch is a UI batch, since values are based on the size of the screen and are ignoring the camera (though one could make it work by wrapping all components in a parent component that is aware of the camera and moves along with it).