### PR TITLE
👨🏽‍🎨 Add hook points to render context

### DIFF
--- a/src/Murder/Core/Graphics/RenderContext.cs
+++ b/src/Murder/Core/Graphics/RenderContext.cs
@@ -332,12 +332,22 @@ public class RenderContext : IDisposable
     }
 
     /// <summary>
+    /// Called right after <see cref="FloorBatch"/>, <see cref="GameplayBatch"/> and <see cref="GameUiBatch"/> end.
+    /// </summary>
+    /// <param name="mainTarget">Main target with the main game drawn in it. This target's size matches the game resolution.</param>
+    protected virtual void AfterMainRender(RenderTarget2D mainTarget) { }
+
+    /// <summary>
+    /// Called right after the <see cref="UiBatch"/> ends.
+    /// </summary>
+    /// <param name="uiTarget">UI target with the game UI drawn in it. This target's size matches the game resolution.</param>
+    protected virtual void AfterUiRender(RenderTarget2D uiTarget) { }
+
+    /// <summary>
     /// Last chance to render anything before the contents are drawn on the screen!
     /// </summary>
-    protected virtual void BeforeScreenRender(RenderTarget2D finalTarget)
-    {
-
-    }
+    /// <param name="finalTarget">Final target containing everything that will be rendered on screen. This target's size is the size of the actual game window, since this is what will be rendered on screen.</param>
+    protected virtual void BeforeScreenRender(RenderTarget2D finalTarget) { }
 
     public virtual void End()
     {
@@ -370,12 +380,16 @@ public class RenderContext : IDisposable
 
         CreateDebugPreviewIfNecessary(BatchPreviewState.Gameplay, _mainTarget);
 
+        AfterMainRender(_mainTarget);
+
         _graphicsDevice.SetRenderTarget(_uiTarget);
         _graphicsDevice.Clear(Color.Transparent);
 
         UiBatch.End();              // <=== Static Ui
 
         CreateDebugPreviewIfNecessary(BatchPreviewState.Ui, _uiTarget);
+
+        AfterUiRender(_uiTarget);
 
         _graphicsDevice.SetRenderTarget(_finalTarget);
 


### PR DESCRIPTION
This adds two extra points to render context, which basically removes most needs to override the End method!

One point happens right after the main game has been drawn and the other one happens right after the UI has been drawn. This means one can now create any number of additional batches and end said batches in these extension points would allow to draw at the correct target at the correct time without having to copy all the code inside the `End` method over to one's project!