### PR TITLE
🕶️ Simplify Custom Shader logic

### DIFF
--- a/src/Murder.Editor/Assets/EditorSettingsAsset.cs
+++ b/src/Murder.Editor/Assets/EditorSettingsAsset.cs
@@ -114,8 +114,6 @@ namespace Murder.Editor.Assets
         /// </summary>
         public ImmutableArray<(Type systemType, bool isActive)> EditorSystems => _editorSystems;
 
-        public bool UseCustomShadersOnEditor = false;
-
         /// <summary>
         /// The default floor tiles to use when creating a new room.
         /// </summary>

--- a/src/Murder.Editor/CustomEditors/PrefabAssetEditor.cs
+++ b/src/Murder.Editor/CustomEditors/PrefabAssetEditor.cs
@@ -28,9 +28,6 @@ namespace Murder.Editor.CustomEditors
                 InitializeStage(new(imGuiRenderer, renderContext, (PrefabAsset)_asset), _asset.Guid);
             }
 
-            // Disable custom shaders on prefab editors.
-            renderContext.SwitchCustomShader(enable: false);
-
             _lastOpenedEntity = _asset as IEntity;
         }
 

--- a/src/Murder.Editor/CustomEditors/WorldAssetEditor.cs
+++ b/src/Murder.Editor/CustomEditors/WorldAssetEditor.cs
@@ -65,9 +65,6 @@ namespace Murder.Editor.CustomEditors
                 InitializeStage(new(imGuiRenderer, renderContext, _world), _world.Guid);
             }
 
-            // Disable custom shaders on prefab editors.
-            renderContext.SwitchCustomShader(enable: Architect.EditorSettings.UseCustomShadersOnEditor);
-
             // Clear cache.
             _entitiesPerGroup.Clear();
         }

--- a/src/Murder.Editor/Systems/Debug/SystemsDiagnosticsSystem.cs
+++ b/src/Murder.Editor/Systems/Debug/SystemsDiagnosticsSystem.cs
@@ -168,7 +168,7 @@ namespace Murder.Editor.Systems
             {
                 if (ImGui.BeginChild("shaders"))
                 {
-                    foreach (var shader in Game.Data.CustomGameShader)
+                    foreach (var shader in Game.Data.CustomGameShaders)
                     {
                         ImGui.TextColored(Game.Profile.Theme.HighAccent, shader.Name);
 

--- a/src/Murder.Editor/Systems/EditorSystem.cs
+++ b/src/Murder.Editor/Systems/EditorSystem.cs
@@ -87,13 +87,10 @@ namespace Murder.Editor.Systems
 
                         ImGui.Separator();
                         ImGui.Text($"Custom Shaders:");
-                        for (int i = 0; i < Game.Data.CustomGameShader.Length; i++)
+                        for (int i = 0; i < Game.Data.CustomGameShaders.Length; i++)
                         {
-                            var shader = Game.Data.CustomGameShader[i];
-                            if (shader != null)
-                            {
-                                ImGui.Text($"{i}:{shader.Name}");
-                            }
+                            var shader = Game.Data.CustomGameShaders[i];
+                            ImGui.Text($"{i}:{shader.Name}");
                         }
 
                         ImGui.SetNextWindowBgAlpha(0.9f);

--- a/src/Murder/Data/GameDataManager.cs
+++ b/src/Murder/Data/GameDataManager.cs
@@ -72,9 +72,9 @@ namespace Murder.Data
         public Effect MaskShader = null!;
 
         /// <summary>
-        /// Custom optional game shader, provided by <see cref="_game"/>.
+        /// Custom optional game shaders, provided by <see cref="_game"/>.
         /// </summary>
-        public Effect[] CustomGameShader = new Effect[0];
+        public Effect[] CustomGameShaders = new Effect[0];
 
         /// <summary>
         /// Current localization data.
@@ -329,14 +329,14 @@ namespace Murder.Data
             if (LoadShader("posterize", out result, breakOnFail, forceReload)) PosterizerShader = result;
             if (LoadShader("mask", out result, breakOnFail, forceReload)) MaskShader = result;
 
-            if (_game is IShaderProvider provider && provider.Shaders.Length > 0)
+            if (_game is IShaderProvider { Shaders.Length: > 0 } provider)
             {
-                CustomGameShader = new Effect[provider.Shaders.Length];
+                CustomGameShaders = new Effect[provider.Shaders.Length];
                 for (int i = 0; i < provider.Shaders.Length; i++)
                 {
                     if (LoadShader(provider.Shaders[i], out var shader, breakOnFail, forceReload))
                     {
-                        CustomGameShader[i] = shader;
+                        CustomGameShaders[i] = shader;
                     }
                 }
             }


### PR DESCRIPTION
This removes a bunch of code that is too specific from the main rendering pipeline. Core changes:

- The first shader from `IShaderProvider` is no longer assumed to be a custom shader that should be used for the entire game
- The concept of a "CustomShader" has been removed entirely, since one can achieve the same with the existing extension points
- Assumptions about the basic shader (like its parameters or technique names) have been removed
- A BatchPreviewState step has been removed