### PR TITLE
🔥 Shader Hot Reloading

### DIFF
--- a/src/Murder.Editor/Assets/EditorSettingsAsset.cs
+++ b/src/Murder.Editor/Assets/EditorSettingsAsset.cs
@@ -103,6 +103,7 @@ namespace Murder.Editor.Assets
         public Guid QuickStartScene;
 
         public bool OnlyReloadAtlasWithChanges = true;
+        public bool HotReloadShaders = true;
 
         public string IgnoredTexturePackingExtensions = ".clip,.psd,.gitkeep";
 

--- a/src/Murder.Editor/EditorScene_Shortcuts.cs
+++ b/src/Murder.Editor/EditorScene_Shortcuts.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Input;
 using Murder.Assets;
 using Murder.Core.Input;
 using Murder.Diagnostics;
+using Murder.Editor.Assets;
 using Murder.Editor.Services;
 using Murder.Editor.Utilities;
 using System.Collections.Immutable;
@@ -47,6 +48,12 @@ public partial class EditorScene
                     chord: new Chord(Keys.F3, Keys.LeftShift),
                     toggle: ReloadAtlasWithChangesToggled,
                     defaultCheckedValue: Architect.EditorSettings.OnlyReloadAtlasWithChanges
+                ),
+                new ToggleShortcut(
+                    name: "Hot Reload Shaders",
+                    chord: new Chord(Keys.F6, Keys.LeftShift),
+                    toggle: HotReloadShadersToggled,
+                    defaultCheckedValue: Architect.EditorSettings.HotReloadShaders
                 )
             ],
             [ShortcutGroup.Tools] =
@@ -174,6 +181,13 @@ public partial class EditorScene
     private void ReloadAtlasWithChangesToggled(bool value)
     {
         Architect.EditorSettings.OnlyReloadAtlasWithChanges = value;
+    }
+
+    private FileSystemWatcher _fileSystemWatcher;
+    private void HotReloadShadersToggled(bool value)
+    {
+        Architect.EditorSettings.HotReloadShaders = value;
+        _fileSystemWatcher.EnableRaisingEvents = value;
     }
 
     private static void ReloadContentAndAtlas()


### PR DESCRIPTION
This is the 0 IQ solution to automatically reloading the shaders: 
- We already have a shader reloading mechanism
- .NET has an out-of-the-box, cross platform file system watcher

I just smashed the two together. Some notes:

- The lock is in place because the FileSystemWatcher is multithreaded and the shader reloading needs to happen on the main thread.
- I thought about optimizing to only reload the shader we need, but, by definition, when the user is editing the shader they won't be looking at the editor, so we can afford to hiccup the main thread when no one is looking 🤷 
- There's a toggle to disable shader hot reloading, should the user not need it or would rather not use it.