### PR TITLE
😵‍💫 Enable flipping in every direction

### DIFF
--- a/src/Murder.Editor/Systems/SpriteRenderDebugSystem.cs
+++ b/src/Murder.Editor/Systems/SpriteRenderDebugSystem.cs
@@ -73,7 +73,7 @@ internal class SpriteRenderDebugSystem : IFixedUpdateSystem, IMurderRenderSystem
             string animationId;
             SpriteAsset? asset;
             float start;
-            bool flip = false;
+            ImageFlip flip = ImageFlip.None;
 
             float ySortOffsetRaw;
 
@@ -171,12 +171,13 @@ internal class SpriteRenderDebugSystem : IFixedUpdateSystem, IMurderRenderSystem
 
                 if (sprite.Value.FlipWithFacing)
                 {
-                    flip = facing.Direction.GetFlipped() == Microsoft.Xna.Framework.Graphics.SpriteEffects.FlipHorizontally;
+                    flip = facing.Direction.GetFlipped();
                 }
 
                 if (e.TryGetSpriteFacing() is SpriteFacingComponent spriteFacing)
                 {
-                    (animationId, flip)= spriteFacing.GetSuffixFromAngle(facing.Angle);
+                    (animationId, var horizontalFlip)= spriteFacing.GetSuffixFromAngle(facing.Angle);
+                    flip = horizontalFlip ? ImageFlip.Horizontal : ImageFlip.None;
                 }
             }
 
@@ -215,7 +216,7 @@ internal class SpriteRenderDebugSystem : IFixedUpdateSystem, IMurderRenderSystem
                 new DrawInfo()
                 {
                     Origin = offset,
-                    FlippedHorizontal = flip,
+                    ImageFlip = flip,
                     Rotation = rotation,
                     Sort = ySort,
                     Scale = scale,
@@ -230,7 +231,7 @@ internal class SpriteRenderDebugSystem : IFixedUpdateSystem, IMurderRenderSystem
                 CurrentAnimation = frameInfo.Animation,
                 RenderPosition = renderPosition,
                 Offset = sprite?.Offset ?? Vector2.Zero,
-                Flipped = flip,
+                ImageFlip = flip,
                 Rotation = rotation,
                 Scale = scale,
                 Color = baseColor,
@@ -272,7 +273,7 @@ internal class SpriteRenderDebugSystem : IFixedUpdateSystem, IMurderRenderSystem
                     new DrawInfo()
                     {
                         Origin = offset,
-                        FlippedHorizontal = flip,
+                        ImageFlip = flip,
                         Rotation = rotation,
                         Sort = 0,
                         Color = baseColor * reflection.Alpha,
@@ -283,7 +284,7 @@ internal class SpriteRenderDebugSystem : IFixedUpdateSystem, IMurderRenderSystem
         }
     }
 
-    private (string animationId, SpriteAsset? asset, float start, bool flip) GetAgentAsepriteSettings(Entity e)
+    private (string animationId, SpriteAsset? asset, float start, ImageFlip flip) GetAgentAsepriteSettings(Entity e)
     {
         AgentSpriteComponent sprite = e.GetAgentSprite();
         FacingComponent facing = e.GetFacing();
@@ -296,6 +297,6 @@ internal class SpriteRenderDebugSystem : IFixedUpdateSystem, IMurderRenderSystem
 
         SpriteAsset? SpriteAsset = Game.Data.TryGetAsset<SpriteAsset>(sprite.AnimationGuid);
 
-        return (prefix + suffix, SpriteAsset, start, flip);
+        return (prefix + suffix, SpriteAsset, start, flip ? ImageFlip.Horizontal : ImageFlip.None);
     }
 }

--- a/src/Murder/Components/Graphics/RenderedSpriteCacheComponent.cs
+++ b/src/Murder/Components/Graphics/RenderedSpriteCacheComponent.cs
@@ -16,7 +16,7 @@ namespace Murder.Components.Graphics
         public readonly Vector2 Offset { get; init; }
         public readonly float Rotation { get; init; }
         public readonly Guid RenderedSprite { get; init; }
-        public readonly bool Flipped { get; init; }
+        public readonly ImageFlip ImageFlip { get; init; }
         public readonly float Sorting { get; init; }
         public readonly BlendStyle Blend { get; init; }
         public readonly AnimationInfo AnimInfo { get; init; }

--- a/src/Murder/Core/Graphics/Batch/SpriteBatchItem.cs
+++ b/src/Murder/Core/Graphics/Batch/SpriteBatchItem.cs
@@ -150,9 +150,14 @@ public class SpriteBatchItem
 
             // Apply offset and flipping
             transformedVertex += drawInfo.Offset;
-            if (drawInfo.FlippedHorizontal)
+            if (drawInfo.ImageFlip.HasFlag(ImageFlip.Horizontal))
             {
                 transformedVertex.X = -transformedVertex.X;
+            }
+            
+            if (drawInfo.ImageFlip.HasFlag(ImageFlip.Vertical))
+            {
+                transformedVertex.Y = -transformedVertex.Y;
             }
 
             VertexData[i] = new VertexInfo(

--- a/src/Murder/Core/Graphics/DrawInfo.cs
+++ b/src/Murder/Core/Graphics/DrawInfo.cs
@@ -54,7 +54,7 @@ public readonly struct DrawInfo
     public bool Debug { get; init; } = false;
 
     public BlendStyle BlendMode { get; init; } = BlendStyle.Normal;
-    public bool FlippedHorizontal { get; init; } = false;
+    public ImageFlip ImageFlip { get; init; } = ImageFlip.None;
 
     public Rectangle Clip { get; init; } = Rectangle.Empty;
 
@@ -97,7 +97,7 @@ public readonly struct DrawInfo
             Shadow = Shadow,
             Outline = Outline,
             BlendMode = BlendMode,
-            FlippedHorizontal = FlippedHorizontal,
+            ImageFlip = ImageFlip,
             Debug = Debug
         };
     }
@@ -115,7 +115,7 @@ public readonly struct DrawInfo
             Shadow = Shadow,
             Outline = Outline,
             BlendMode = BlendMode,
-            FlippedHorizontal = FlippedHorizontal,
+            ImageFlip = ImageFlip,
             Debug = Debug
         };
     }
@@ -131,7 +131,7 @@ public readonly struct DrawInfo
         Shadow = Shadow,
         Outline = Outline,
         BlendMode = BlendMode,
-        FlippedHorizontal = FlippedHorizontal,
+        ImageFlip = ImageFlip,
         Debug = Debug
     };
 

--- a/src/Murder/Core/Graphics/ImageFlip.cs
+++ b/src/Murder/Core/Graphics/ImageFlip.cs
@@ -1,13 +1,10 @@
-﻿using System;
+﻿namespace Murder.Core.Graphics;
 
-namespace Murder.Core.Graphics
+[Flags]
+public enum ImageFlip
 {
-    [Flags]
-    public enum ImageFlip
-    {
-        None = 0,
-        Horizontal = 1,
-        Vertical = 1 << 1,
-        Both = Horizontal | Vertical
-    }
+    None = 0,
+    Horizontal = 1,
+    Vertical = 1 << 1,
+    Both = Horizontal | Vertical
 }

--- a/src/Murder/Core/Graphics/Mask2D.cs
+++ b/src/Murder/Core/Graphics/Mask2D.cs
@@ -69,7 +69,7 @@ public class Mask2D : IDisposable
     {
         _batch.End();
         targetBatch.Draw(_renderTarget, position, _renderTarget.Bounds.Size.ToVector2(), _renderTarget.Bounds, drawInfo.Sort,
-            drawInfo.Rotation, drawInfo.Scale, drawInfo.FlippedHorizontal ? ImageFlip.Horizontal : ImageFlip.None, drawInfo.Color,
+            drawInfo.Rotation, drawInfo.Scale, drawInfo.ImageFlip, drawInfo.Color,
             drawInfo.Origin, drawInfo.GetBlendMode());
     }
 

--- a/src/Murder/Services/RenderServices.cs
+++ b/src/Murder/Services/RenderServices.cs
@@ -169,7 +169,7 @@ namespace Murder.Services
             float animationDuration,
             bool animationLoop,
             Vector2 origin,
-            bool flipped,
+            ImageFlip imageFlip,
             float rotation,
             Vector2 scale,
             Color color,
@@ -177,8 +177,6 @@ namespace Murder.Services
             float sort,
             float currentTime)
         {
-            ImageFlip imageFlip = flipped ? ImageFlip.Horizontal : ImageFlip.None;
-
             if (!ase.Animations.TryGetValue(animationId, out var animation))
             {
                 GameLogger.Log($"Couldn't find animation {animationId}.");
@@ -270,7 +268,7 @@ namespace Murder.Services
                 drawInfo.Sort,
                 drawInfo.Rotation,
                 drawInfo.Scale,
-                drawInfo.FlippedHorizontal ? ImageFlip.Horizontal : ImageFlip.None,
+                drawInfo.ImageFlip,
                 drawInfo.Color,
                 drawInfo.Origin,
                 BLEND_NORMAL
@@ -309,7 +307,7 @@ namespace Murder.Services
                 animationInfo.Duration,
                 animationInfo.Loop,
                 drawInfo.Origin,
-                drawInfo.FlippedHorizontal,
+                drawInfo.ImageFlip,
                 drawInfo.Rotation,
                 drawInfo.Scale,
                 color,

--- a/src/Murder/Systems/Agents/AgentSpriteSystem.cs
+++ b/src/Murder/Systems/Agents/AgentSpriteSystem.cs
@@ -165,7 +165,7 @@ namespace Murder.Systems
                     position: renderPosition,
                     new DrawInfo(ySort)
                     {
-                        FlippedHorizontal = flip,
+                        ImageFlip = flip ? ImageFlip.Horizontal : ImageFlip.None,
                         Color = color,
                         Scale = scale,
                         BlendMode = blend,
@@ -178,7 +178,7 @@ namespace Murder.Systems
                     RenderedSprite = spriteAsset.Guid,
                     CurrentAnimation = frameInfo.Animation,
                     RenderPosition = renderPosition,
-                    Flipped = flip,
+                    ImageFlip = flip ? ImageFlip.Horizontal : ImageFlip.None,
                     Rotation = 0,
                     Scale = scale,
                     Color = color,

--- a/src/Murder/Systems/Graphics/ParticleRendererSystem.cs
+++ b/src/Murder/Systems/Graphics/ParticleRendererSystem.cs
@@ -131,7 +131,7 @@ namespace Murder.Systems
                                 animationDuration: -1,
                                 animationLoop: true,
                                 origin: Vector2.Zero,
-                                flipped: false,
+                                imageFlip: ImageFlip.None,
                                 rotation: particle.Rotation,
                                 scale: scale,
                                 color,

--- a/src/Murder/Systems/Graphics/SpriteRenderSystem.cs
+++ b/src/Murder/Systems/Graphics/SpriteRenderSystem.cs
@@ -24,7 +24,7 @@ namespace Murder.Systems.Graphics
         {
             foreach (Entity e in context.Entities)
             {
-                bool flip = false;
+                ImageFlip flip = ImageFlip.None;
 
                 IMurderTransformComponent transform = e.GetGlobalTransform();
                 SpriteComponent s = e.GetSprite();
@@ -54,7 +54,7 @@ namespace Murder.Systems.Graphics
                 if (facing is not null)
                 {
                     if (s.RotateWithFacing) rotation += DirectionHelper.ToAngle(facing.Value.Direction);
-                    if (s.FlipWithFacing && facing.Value.Direction.Flipped()) flip = true;
+                    if (s.FlipWithFacing && facing.Value.Direction.Flipped()) flip &= ImageFlip.Horizontal;
                 }
 
                 // Handle color
@@ -124,7 +124,7 @@ namespace Murder.Systems.Graphics
                     new DrawInfo(ySort)
                     {
                         Origin = s.Offset,
-                        FlippedHorizontal = flip,
+                        ImageFlip = flip,
                         Rotation = rotation,
                         Scale = scale,
                         Color = color,
@@ -140,7 +140,7 @@ namespace Murder.Systems.Graphics
                     CurrentAnimation = frameInfo.Animation,
                     RenderPosition = renderPosition,
                     Offset = s.Offset,
-                    Flipped = flip,
+                    ImageFlip = flip,
                     Rotation = rotation,
                     Scale = scale,
                     Color = color,

--- a/src/Murder/Utilities/DirectionHelper.cs
+++ b/src/Murder/Utilities/DirectionHelper.cs
@@ -2,11 +2,13 @@
 using Microsoft.Xna.Framework.Graphics;
 using Murder.Components;
 using Murder.Core;
+using Murder.Core.Graphics;
 using Murder.Diagnostics;
 using Murder.Utilities;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Numerics;
+using System.Security;
 
 namespace Murder.Helpers;
 
@@ -224,14 +226,14 @@ public static class DirectionHelper
         return FromVector(direction.ToVector().Reverse());
     }
 
-    public static SpriteEffects GetFlipped(this Direction direction)
+    public static ImageFlip GetFlipped(this Direction direction)
     {
-        var x = ToVector(direction).X;
-        if (x < 0)
-            return SpriteEffects.FlipHorizontally;
-        else
-            return SpriteEffects.None;
+        var vector = ToVector(direction);
+        var horizontalFlags = vector.X < 0 ? ImageFlip.Horizontal : ImageFlip.None;
+        var verticalFlags = vector.Y < 0 ? ImageFlip.Vertical : ImageFlip.None;
+        return horizontalFlags & verticalFlags;
     }
+
     public static bool Flipped(this Direction direction)
     {
         var x = ToVector(direction).X;


### PR DESCRIPTION
I could heavily simplify a little something by allowing my sprite to rotate freely instead of adding multiple sprites. When trying to enable that in murder, I noticed that we already have everything in place, including an enum for controlling how the flipping should happen, but we were limiting it to horizontal flipping only on the `DrawInfo`. This patches that behavior