### PR TITLE
🫥 Add highlight style copy method

### DIFF
--- a/src/Murder/Components/Graphics/SpriteComponent.cs
+++ b/src/Murder/Components/Graphics/SpriteComponent.cs
@@ -132,5 +132,16 @@ namespace Murder.Components
             AnimationGuid = portrait.Sprite,
             NextAnimations = [portrait.AnimationId]
         };
+        
+        public SpriteComponent WithHighlightStyle(OutlineStyle newHighlightStyle) => new(
+            AnimationGuid,
+            Offset,
+            NextAnimations,
+            YSortOffset,
+            RotateWithFacing,
+            FlipWithFacing,
+            newHighlightStyle,
+            TargetSpriteBatch
+        );
     }
 }


### PR DESCRIPTION
This adds a copy method that is handy since `CanBeHighlighted` has been removed