### PR TITLE
🎨 Command palette

### DIFF
--- a/src/Murder.Editor/EditorScene.cs
+++ b/src/Murder.Editor/EditorScene.cs
@@ -53,6 +53,9 @@ namespace Murder.Editor
             _selectedExplorerWindow = _explorerPages.First();
 
             _shortcuts = CreateShortcutList();
+            _shortcutSearchValues = _shortcuts
+                .Keys.SelectMany(group => _shortcuts[group].Select(shortcut => (group, shortcut)))
+                .ToDictionary(tuple => $"{tuple.group} > {tuple.shortcut.Name}", tuple => tuple.shortcut);
         }
 
         /// <summary>

--- a/src/Murder.Editor/EditorScene_Shortcuts.cs
+++ b/src/Murder.Editor/EditorScene_Shortcuts.cs
@@ -3,15 +3,28 @@ using Microsoft.Xna.Framework.Input;
 using Murder.Assets;
 using Murder.Core.Input;
 using Murder.Diagnostics;
+using Murder.Editor.ImGuiExtended;
 using Murder.Editor.Services;
 using Murder.Editor.Utilities;
 using System.Collections.Immutable;
+using System.Numerics;
 
 namespace Murder.Editor;
 
 public partial class EditorScene
 {
+    private static readonly Vector2 _commandPaletteWindowSize = new(400, 350);
+    private static readonly Vector2 _commandPalettePadding = new(20, 0);
+    private static readonly Vector2 _commandPaletteSearchBoxPadding = new (20, 20);
+    private static readonly SearchBox.SearchBoxSizeConfiguration _commandPaletteSizeConfiguration = new(
+        SearchFrameSize: _commandPaletteWindowSize - _commandPalettePadding,
+        SearchBoxContainerSize: _commandPaletteWindowSize - _commandPaletteSearchBoxPadding
+    );
+    
     private readonly ImmutableDictionary<ShortcutGroup, List<Shortcut>> _shortcuts;
+    private readonly Dictionary<string, Shortcut> _shortcutSearchValues;
+
+    private bool _commandPaletteIsVisible;
 
     private ImmutableDictionary<ShortcutGroup, List<Shortcut>> CreateShortcutList() =>
         new Dictionary<ShortcutGroup, List<Shortcut>>
@@ -58,9 +71,15 @@ public partial class EditorScene
             [ShortcutGroup.Tools] =
             [
                 new ActionShortcut("Refresh Window", Keys.F4, RefreshEditorWindow),
-                new ActionShortcut("Run diagnostics", new Chord(Keys.D, _leftOsActionModifier, Keys.LeftShift),  RunDiagnostics)
+                new ActionShortcut("Run diagnostics", new Chord(Keys.D, _leftOsActionModifier, Keys.LeftShift),  RunDiagnostics),
+                new ActionShortcut("Command Palette", new Chord(Keys.A, _leftOsActionModifier, Keys.LeftShift), ToggleCommandPalette)
             ]
         }.ToImmutableDictionary();
+
+    private void ToggleCommandPalette()
+    {
+        _commandPaletteIsVisible = !_commandPaletteIsVisible;
+    }
 
     private void ToggleHotReloadShader(bool value)
     {
@@ -143,6 +162,42 @@ public partial class EditorScene
             Game.Input.Shortcut(Keys.F, _rightOsActionModifier))
         {
             _focusOnFind = true;
+        }
+
+        if (_commandPaletteIsVisible)
+        {    
+            Vector2 viewportSize = ImGui.GetMainViewport().Size;
+
+            // Background of the command palette, slightly darker and prevents interaction with the editor.
+            ImGui.SetNextWindowBgAlpha(0.5f);
+            ImGui.Begin("Command Palette Background", ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoResize);
+            ImGui.SetWindowPos(Vector2.Zero);
+            ImGui.SetWindowSize(viewportSize);
+            ImGui.End();
+            
+            // Command palette window.
+            ImGui.Begin("Command Palette",  ImGuiWindowFlags.Modal | ImGuiWindowFlags.NoDecoration);
+            ImGui.SetWindowPos((viewportSize - _commandPaletteWindowSize) / 2f);
+            ImGui.SetWindowPos((viewportSize - _commandPaletteWindowSize) / 2f);
+            ImGui.SetWindowSize(_commandPaletteWindowSize);
+            ImGui.SetWindowFocus();
+
+            var lazy = new Lazy<Dictionary<string, Shortcut>>(() => _shortcutSearchValues);
+
+            if (SearchBox.Search(
+                    $"command_palette",
+                    hasInitialValue: false,
+                    selected: "",
+                    values: lazy,
+                    flags: SearchBoxFlags.Unfolded,
+                    sizeConfiguration: _commandPaletteSizeConfiguration, out var shortcut)
+                )
+            {
+                shortcut.Execute();
+                _commandPaletteIsVisible = false;
+            }
+            
+            ImGui.End();
         }
     }
 

--- a/src/Murder.Editor/EditorScene_Shortcuts.cs
+++ b/src/Murder.Editor/EditorScene_Shortcuts.cs
@@ -147,9 +147,19 @@ public partial class EditorScene
 
         ImGui.EndMainMenuBar();
         
-        if (Game.Input.Shortcut(Keys.Escape) && GameLogger.IsShowing)
+        // We need to check for the visibility of escapable elements in order and dismiss whatever is on top.
+        if (Game.Input.Shortcut(Keys.Escape))
         {
-            ToggleGameLogger();
+            // First, we hide the command palette, since it takes the whole screen.
+            if (_commandPaletteIsVisible)
+            {
+                _commandPaletteIsVisible = false;
+            }
+            // Next we hide the logger.
+            else if (GameLogger.IsShowing)
+            {
+                ToggleGameLogger();
+            }
         }
         
         if (Game.Input.Shortcut(Keys.W, _leftOsActionModifier) ||

--- a/src/Murder.Editor/Utilities/Gui/SearchBox.cs
+++ b/src/Murder.Editor/Utilities/Gui/SearchBox.cs
@@ -402,8 +402,19 @@ namespace Murder.Editor.ImGuiExtended
             string selected,
             Lazy<Dictionary<string, T>> values,
             SearchBoxFlags flags,
+            [NotNullWhen(true)] out T? result
+        ) => Search(id, hasInitialValue, selected, values, flags, SearchBoxSizeConfiguration.Default, out result);
+
+        public static bool Search<T>(
+            string id,
+            bool hasInitialValue,
+            string selected,
+            Lazy<Dictionary<string, T>> values,
+            SearchBoxFlags flags,
+            SearchBoxSizeConfiguration sizeConfiguration,
             [NotNullWhen(true)] out T? result)
         {
+            
             result = default;
 
             bool modified = false;
@@ -516,7 +527,7 @@ namespace Murder.Editor.ImGuiExtended
             }
             else
             {
-                ImGui.BeginChild(id + "_search_frame", new Vector2(150,200), ImGuiChildFlags.None, ImGuiWindowFlags.NoMove);
+                ImGui.BeginChild(id + "_search_frame", sizeConfiguration.SearchFrameSize, ImGuiChildFlags.None, ImGuiWindowFlags.NoMove);
             }
             var pos = ImGui.GetItemRectMin();
 
@@ -526,7 +537,7 @@ namespace Murder.Editor.ImGuiExtended
                 pos = new(pos.X, pos.Y + Math.Min(0, ImGui.GetWindowViewport().Size.Y - pos.Y - 400));
                 ImGui.SetWindowPos(pos);
 
-                ImGui.BeginChild("##Searchbox_containter", new Vector2(250, 400), ImGuiChildFlags.Border);
+                ImGui.BeginChild("##Searchbox_containter", sizeConfiguration.SearchBoxContainerSize, ImGuiChildFlags.Border);
 
                 if (ImGui.IsWindowAppearing())
                 {
@@ -548,6 +559,7 @@ namespace Murder.Editor.ImGuiExtended
                         {
                             modified = true;
                             result = asset;
+                            _tempSearchText = string.Empty;
 
                             ImGui.CloseCurrentPopup();
                         }
@@ -622,6 +634,17 @@ namespace Murder.Editor.ImGuiExtended
             }
 
             return modified;
+        }
+
+        public readonly record struct SearchBoxSizeConfiguration(
+            Vector2 SearchFrameSize,
+            Vector2 SearchBoxContainerSize
+        )
+        {
+            public static SearchBoxSizeConfiguration Default = new(
+                SearchFrameSize: new Vector2(150, 200),
+                SearchBoxContainerSize: new Vector2(250, 400)
+            );
         }
     }
 }


### PR DESCRIPTION
This implements a command palette, which allows for searching and executing all commands from the menu bar. This is a followup of #59, meaning that all new shortcuts added to the menu bar will automatically be searchable from the command palette.

Usage is simple: Press Ctrl (or Cmd) + Shift + A, which will bring up a search box that can be filtered by typing. Selecting any command from that searchbox will execute that command; pressing esc will dismiss the command palette.

I had to create a parameterized overload of `Search<T>` so as to not break the current behavior of all search boxes while allowing for its size to change in this new use case. This can be useful in more scenarios (since right now all search boxes have the same size, we can make them have different size settings based on where they are being displayed, for example).

Demo:
![command_palette](https://github.com/isadorasophia/murder/assets/7688727/aa0f621d-bcb7-4de4-9d86-365cf4056899)
