### PR TITLE
feat: improve entity movement in editor

### DIFF
--- a/src/Murder.Editor/Systems/EditorCameraControllerSystem.cs
+++ b/src/Murder.Editor/Systems/EditorCameraControllerSystem.cs
@@ -53,11 +53,13 @@ namespace Murder.Editor.Systems
                 }
                 else
                 {
+                    bool noEntitiesSelected = hook.AllSelectedEntities.IsEmpty;
+
                     if (ImGui.GetIO().WantTextInput)
                     {
                         // Handled by ImGui
                     }
-                    else if (!Game.Input.Down(Keys.LeftControl))
+                    else if (!Game.Input.Down(Keys.LeftControl) && noEntitiesSelected)
                     {
                         Vector2 cameraMovement = Architect.Input.GetAxis(MurderInputAxis.EditorCamera).Value * Game.DeltaTime * Architect.EditorSettings.WasdCameraSpeed * Math.Clamp((1f / hook.CurrentZoomLevel), .75f, 10f);
                         if (Game.Input.Down(Keys.LeftShift))


### PR DESCRIPTION
an attempt at addressing #74 

- when an entity is selected, using the arrow keys will change its position by 1 pixel in the corresponding direction
- holding shift while doing this will move by 1 tile
- holding shift while dragging an entity will constrain it to the direction you are dragging in