### PR TITLE
💥 Prevent crash after deleting bin/obj

### DIFF
--- a/src/Murder.Editor/Importers/AsepriteImporter.cs
+++ b/src/Murder.Editor/Importers/AsepriteImporter.cs
@@ -202,7 +202,7 @@ namespace Murder.Editor.Importers
 
         private void SerializeAtlas(AtlasId targetAtlasId, Packer packer, SerializeAtlasFlags flags)
         {
-            TextureAtlas atlas = Game.Data.FetchAtlas(targetAtlasId);
+            TextureAtlas atlas = Game.Data.TryFetchAtlas(targetAtlasId) ?? new TextureAtlas(targetAtlasId.GetDescription(), targetAtlasId);
             string atlasName = targetAtlasId.GetDescription();
 
             // Delete any previous atlas in the source directory.


### PR DESCRIPTION
This makes sure that the AsepriteImporter is resilient enough to not explode when the atlas file is not found (e.g.: when the bin/obj folders are deleted)