### PR TITLE
🗑️ Prevent allocations on HasFlag checks

### DIFF
--- a/src/Murder/Core/Extensions/EnumExtensions.cs
+++ b/src/Murder/Core/Extensions/EnumExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Murder.Core.Extensions;
+
+internal static class EnumExtensions
+{
+    /// <summary>
+    /// Implementation of .HasFlag which does not box the Enum and thus does not allocate. Useful in parts
+    /// where a `HasFlag` check needs to happen every frame.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool NonAllocatingHasFlag<TEnum>(this TEnum lhs, TEnum rhs) where TEnum : unmanaged, Enum
+    {
+        unsafe
+        {
+            return sizeof(TEnum) switch
+            {
+                1 => (*(byte*)(&lhs) & *(byte*)(&rhs)) > 0,
+                2 => (*(ushort*)(&lhs) & *(ushort*)(&rhs)) > 0,
+                4 => (*(uint*)(&lhs) & *(uint*)(&rhs)) > 0,
+                8 => (*(ulong*)(&lhs) & *(ulong*)(&rhs)) > 0,
+                _ => throw new Exception("Size does not match a known Enum backing type.")
+            };
+        }
+    }
+}

--- a/src/Murder/Core/Graphics/Batch/SpriteBatchItem.cs
+++ b/src/Murder/Core/Graphics/Batch/SpriteBatchItem.cs
@@ -1,8 +1,10 @@
 ﻿// Based on https://github.com/lucas-miranda/Raccoon
 
 using Microsoft.Xna.Framework.Graphics;
+using Murder.Core.Extensions;
 using Murder.Core.Geometry;
 using Murder.Utilities;
+using System.Runtime.CompilerServices;
 using Vector2 = Microsoft.Xna.Framework.Vector2;
 using Vector3 = Microsoft.Xna.Framework.Vector3;
 
@@ -151,12 +153,12 @@ public class SpriteBatchItem
 
             // Apply offset and flipping
             transformedVertex += drawInfo.Offset.ToXnaVector2();
-            if (drawInfo.ImageFlip.HasFlag(ImageFlip.Horizontal))
+            if (drawInfo.ImageFlip.NonAllocatingHasFlag(ImageFlip.Horizontal))
             {
                 transformedVertex.X = -transformedVertex.X;
             }
             
-            if (drawInfo.ImageFlip.HasFlag(ImageFlip.Vertical))
+            if (drawInfo.ImageFlip.NonAllocatingHasFlag(ImageFlip.Vertical))
             {
                 transformedVertex.Y = -transformedVertex.Y;
             }
@@ -177,6 +179,4 @@ public class SpriteBatchItem
             IndexData[i * 3 + 2] = i + 2;
         }
     }
-
-
 }

--- a/src/Murder/Core/Graphics/PixelFont.cs
+++ b/src/Murder/Core/Graphics/PixelFont.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using Murder.Assets.Graphics;
+using Murder.Core.Extensions;
 using Murder.Core.Geometry;
 using Murder.Diagnostics;
 using Murder.Services;
@@ -258,7 +259,7 @@ public class PixelFontSize
             
 
             bool isPostAddedLineEnding = letter?.Properties is not RuntimeLetterPropertiesFlag properties || 
-                !properties.HasFlag(RuntimeLetterPropertiesFlag.DoNotSkipLineEnding);
+                !properties.NonAllocatingHasFlag(RuntimeLetterPropertiesFlag.DoNotSkipLineEnding);
 
             if (character == '\n')
             {
@@ -295,16 +296,16 @@ public class PixelFontSize
                     {
                         glitchAmount = letter.Value.Glitch;
                     }
-                    if (letter.Value.Properties.HasFlag(RuntimeLetterPropertiesFlag.ResetGlitch))
+                    if (letter.Value.Properties.NonAllocatingHasFlag(RuntimeLetterPropertiesFlag.ResetGlitch))
                     {
                         glitchAmount = 0;
                     }
 
-                    if (letter.Value.Properties.HasFlag(RuntimeLetterPropertiesFlag.Wave))
+                    if (letter.Value.Properties.NonAllocatingHasFlag(RuntimeLetterPropertiesFlag.Wave))
                     {
                         waveOffset = MathF.Sin(Game.NowUnscaled * 4f + i);
                     }
-                    if (letter.Value.Properties.HasFlag(RuntimeLetterPropertiesFlag.Fear))
+                    if (letter.Value.Properties.NonAllocatingHasFlag(RuntimeLetterPropertiesFlag.Fear))
                     {
                         float amplitude = .9f;
                         float smoothFactor = Math.Abs(MathF.Sin(Game.NowUnscaled * 16f + i * 2));
@@ -397,7 +398,7 @@ public class PixelFontSize
                     {
                         currentColor = newColor * color.A;
                     }
-                    else if (letter.Value.Properties.HasFlag(RuntimeLetterPropertiesFlag.ResetColor))
+                    else if (letter.Value.Properties.NonAllocatingHasFlag(RuntimeLetterPropertiesFlag.ResetColor))
                     {
                         currentColor = color;
                     }

--- a/src/Murder/Core/Input/PlayerInput.cs
+++ b/src/Murder/Core/Input/PlayerInput.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework.Input;
+using Murder.Core.Extensions;
 using Murder.Core.Geometry;
 using Murder.Diagnostics;
 using Murder.Utilities;
@@ -523,13 +524,13 @@ namespace Murder.Core.Input
                 if (selectedOptionX >= currentWidth) // Is on last row and it has less than width.
                 {
                     overflow = 1;
-                    if (gridMenuFlags.HasFlag(GridMenuFlags.ClampRight))
+                    if (gridMenuFlags.NonAllocatingHasFlag(GridMenuFlags.ClampRight))
                         selectedOptionX = currentWidth - 1;
                 }
                 else if (selectedOptionX < 0)
                 {
                     overflow = -1;
-                    if (gridMenuFlags.HasFlag(GridMenuFlags.ClampLeft))
+                    if (gridMenuFlags.NonAllocatingHasFlag(GridMenuFlags.ClampLeft))
                         selectedOptionX = 0;
                 }
 
@@ -544,7 +545,7 @@ namespace Murder.Core.Input
 
                 int currentHeight = selectedOptionX >= lastRowWidth ? height - 1 : height;
 
-                if (selectedOptionY >= currentHeight && gridMenuFlags.HasFlag(GridMenuFlags.ClampBottom))
+                if (selectedOptionY >= currentHeight && gridMenuFlags.NonAllocatingHasFlag(GridMenuFlags.ClampBottom))
                 {
                     selectedOptionY = currentHeight - 1;
                 }
@@ -606,13 +607,13 @@ namespace Murder.Core.Input
                 if (selectedOptionX >= currentWidth) // Is on last row and it has less than width.
                 {
                     overflow = 1;
-                    if (gridMenuFlags.HasFlag(GridMenuFlags.ClampRight))
+                    if (gridMenuFlags.NonAllocatingHasFlag(GridMenuFlags.ClampRight))
                         selectedOptionX = currentWidth - 1;
                 }
                 else if (selectedOptionX < 0)
                 {
                     overflow = -1;
-                    if (gridMenuFlags.HasFlag(GridMenuFlags.ClampLeft))
+                    if (gridMenuFlags.NonAllocatingHasFlag(GridMenuFlags.ClampLeft))
                         selectedOptionX = 0;
                 }
 
@@ -627,7 +628,7 @@ namespace Murder.Core.Input
 
                 int currentHeight = selectedOptionX >= lastRowWidth ? height - 1 : height;
 
-                if (selectedOptionY >= currentHeight && gridMenuFlags.HasFlag(GridMenuFlags.ClampBottom))
+                if (selectedOptionY >= currentHeight && gridMenuFlags.NonAllocatingHasFlag(GridMenuFlags.ClampBottom))
                 {
                     selectedOptionY = currentHeight - 1;
                 }

--- a/src/Murder/Data/Save/SavedWorldBuilder.cs
+++ b/src/Murder/Data/Save/SavedWorldBuilder.cs
@@ -4,6 +4,7 @@ using Bang.Entities;
 using Murder.Assets;
 using Murder.Attributes;
 using Murder.Components;
+using Murder.Core.Extensions;
 using Murder.Core.Graphics;
 using Murder.Prefabs;
 using Murder.Utilities;
@@ -87,9 +88,9 @@ namespace Murder.Save
             //}
 
             InstancePersistKind kind = FilterComponents(ref instance, e);
-            if (!kind.HasFlag(InstancePersistKind.All))
+            if (!kind.NonAllocatingHasFlag(InstancePersistKind.All))
             {
-                if (kind.HasFlag(InstancePersistKind.NoChildren))
+                if (kind.NonAllocatingHasFlag(InstancePersistKind.NoChildren))
                 {
                     // Skip persisting any of its children.
                     foreach (int childId in e.Children)

--- a/src/Murder/Interactions/AddChildOnInteraction.cs
+++ b/src/Murder/Interactions/AddChildOnInteraction.cs
@@ -3,6 +3,7 @@ using Bang.Entities;
 using Bang.Interactions;
 using Murder.Assets;
 using Murder.Components;
+using Murder.Core.Extensions;
 using Murder.Diagnostics;
 using Murder.Utilities;
 
@@ -42,7 +43,7 @@ namespace Murder.Interactions
             Entity child = _child.Asset.CreateAndFetch(world);
             interacted.AddChild(child.EntityId, _name);
 
-            if (_properties.HasFlag(AddChildProperties.SendEventComponentToParent) && 
+            if (_properties.NonAllocatingHasFlag(AddChildProperties.SendEventComponentToParent) && 
                 child.TryGetEventListener() is EventListenerComponent c)
             {
                 EventListenerComponent? previousEvent = interacted.TryGetEventListener();

--- a/src/Murder/Services/RenderServices.cs
+++ b/src/Murder/Services/RenderServices.cs
@@ -4,6 +4,7 @@ using Murder.Assets.Graphics;
 using Murder.Components;
 using Murder.Components.Graphics;
 using Murder.Core;
+using Murder.Core.Extensions;
 using Murder.Core.Geometry;
 using Murder.Core.Graphics;
 using Murder.Core.Input;
@@ -345,22 +346,22 @@ namespace Murder.Services
 
             if (drawInfo.Outline.HasValue && drawInfo.OutlineStyle != OutlineStyle.None)
             {
-                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.Bottom))
+                if (drawInfo.OutlineStyle.NonAllocatingHasFlag(OutlineStyle.Bottom))
                 {
                     drawAt(position + new Vector2(0, 1), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
                 }
 
-                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.Top))
+                if (drawInfo.OutlineStyle.NonAllocatingHasFlag(OutlineStyle.Top))
                 {
                     drawAt(position + new Vector2(0, -1), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
                 }
 
-                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.Left))
+                if (drawInfo.OutlineStyle.NonAllocatingHasFlag(OutlineStyle.Left))
                 {
                     drawAt(position + new Vector2(-1, 0), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
                 }
 
-                if (drawInfo.OutlineStyle.HasFlag(OutlineStyle.Right))
+                if (drawInfo.OutlineStyle.NonAllocatingHasFlag(OutlineStyle.Right))
                 {
                     drawAt(position + new Vector2(1, 0), drawInfo.Outline.Value, true, drawInfo.Sort + 0.0001f);
                 }
@@ -371,7 +372,7 @@ namespace Murder.Services
                 int shadowOffset = 1;
 
                 // Make sure the shadow shows up even if there is an outline.
-                if (drawInfo.Outline.HasValue && drawInfo.OutlineStyle.HasFlag(OutlineStyle.Bottom))
+                if (drawInfo.Outline.HasValue && drawInfo.OutlineStyle.NonAllocatingHasFlag(OutlineStyle.Bottom))
                 {
                     shadowOffset = 2;
                 }


### PR DESCRIPTION
`.HasFlag` boxes the enum value. When doing that in a Draw method is allocates a bunch. I took [this implementation](https://stackoverflow.com/a/68160028/3465182) of `HasFlag` which doesn't and used it where it made sense (AKA in methods that run every frame).