### PR TITLE
Alt+Click+Drag duplicates entities in the editor

### DIFF
--- a/src/Murder.Editor/Components/EditorTween.cs
+++ b/src/Murder.Editor/Components/EditorTween.cs
@@ -1,4 +1,5 @@
 ﻿using Bang.Components;
+using Murder.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +15,7 @@ public enum EditorTweenType
     Move,
 }
 
+[DoNotPersistOnSave]
 public readonly struct EditorTween : IComponent
 {
     public readonly float StartTime;

--- a/src/Murder.Editor/Systems/GenericSelectorSystem.cs
+++ b/src/Murder.Editor/Systems/GenericSelectorSystem.cs
@@ -417,8 +417,8 @@ namespace Murder.Editor.Systems
                                     components.Add(component);
                                 }
 
-                                string entityName = hook.GetNameForEntityId?.Invoke(id) ?? "";
-                                string groupName = EditorTileServices.FindTargetGroup(world, hook, cursorPosition) ?? "";
+                                string? entityName = hook.GetNameForEntityId?.Invoke(id);
+                                string? groupName = EditorTileServices.FindTargetGroup(world, hook, cursorPosition);
 
                                 hook.AddEntityWithStage?.Invoke([.. components], groupName, entityName);
                             }

--- a/src/Murder.Editor/Systems/GenericSelectorSystem.cs
+++ b/src/Murder.Editor/Systems/GenericSelectorSystem.cs
@@ -410,8 +410,7 @@ namespace Murder.Editor.Systems
                                 {
                                     Type type = component.GetType();
 
-                                    //if (component is not IsSelectedComponent and not RenderedSpriteCacheComponent and not EditorTween)
-                                    if (type.IsDefined(typeof(DoNotPersistOnSaveAttribute), true) || type == typeof(EditorTween))
+                                    if (type.IsDefined(typeof(DoNotPersistOnSaveAttribute), true))
                                     {
                                         continue;
                                     }

--- a/src/Murder.Editor/Systems/GenericSelectorSystem.cs
+++ b/src/Murder.Editor/Systems/GenericSelectorSystem.cs
@@ -410,11 +410,10 @@ namespace Murder.Editor.Systems
                                 {
                                     Type type = component.GetType();
 
-                                    if (type.IsDefined(typeof(DoNotPersistOnSaveAttribute), true))
+                                    if (!type.IsDefined(typeof(DoNotPersistOnSaveAttribute), true))
                                     {
-                                        continue;
+                                        components.Add(component);
                                     }
-                                    components.Add(component);
                                 }
 
                                 string? entityName = hook.GetNameForEntityId?.Invoke(id);


### PR DESCRIPTION
This implements duplicating entities by holding alt and dragging an entity as described in #74.

The extra check for the `DoNotPersitsOnSaveAttribute` is necessary, because saving those components makes the entire world fail to deserialise (which is also why I had to add it to `EditorTween`). Maybe this check should actually be in `hook.AddEntityWithStage`, since I can't see why those components should ever be added to the asset.