### PR TITLE
handle tint in AgentSpriteSystem

### DIFF
--- a/src/Murder/Systems/Agents/AgentSpriteSystem.cs
+++ b/src/Murder/Systems/Agents/AgentSpriteSystem.cs
@@ -134,6 +134,12 @@ namespace Murder.Systems
                 {
                     color = Color.White;
                 }
+                
+                // Handle tint
+                if (e.TryGetTint() is TintComponent tint)
+                {
+                    color *= tint.TintColor;
+                }
 
                 // Handle scaling
                 Vector2 scale = Vector2.One;


### PR DESCRIPTION
without this change, tint was only applied for `SpriteComponent` but not `AgentSpriteComponent`