### PR TITLE
✅ Respect enabled flags in editor

### DIFF
--- a/src/Murder.Editor/Utilities/Gui/ImGuiHelpers.cs
+++ b/src/Murder.Editor/Utilities/Gui/ImGuiHelpers.cs
@@ -643,7 +643,7 @@ public static class ImGuiHelpers
                 continue;
             }
 
-            bool isChecked = (value & intValue) != 0;
+            bool isChecked = ~(~value | intValue) == 0;
 
             if (ImGui.Checkbox($"##{id}-{i}-col-layer", ref isChecked))
             {


### PR DESCRIPTION
When your enum has the `Flags` attribute, there's a cool checkbox editor that automatically selects/deselects the correct checkboxes based on whether the asset's property has that flag set or not. For enum values that have multiple bits set, however, having any bit set will cause the checkbox to be checked, which is not the correct behavior.

https://github.com/user-attachments/assets/c29c239a-8fe2-4586-8189-e6711bd38936

This PR changes the verification of each bit to be `!A || B` instead, making it so that a value which needs both bits set will only be checked if ALL needed bits are set.

https://github.com/user-attachments/assets/60ce608c-85b1-4324-9207-321b1fa63a5e

