### PR TITLE
🥳 Harden particle system

### DIFF
--- a/src/Murder/Core/Particles/Data/EmitterShape.cs
+++ b/src/Murder/Core/Particles/Data/EmitterShape.cs
@@ -27,6 +27,7 @@ namespace Murder.Core.Particles
                     return Vector2.Lerp(Line.Start, Line.End, random.NextFloat());
 
                 case EmitterShapeKind.Circle:
+                case EmitterShapeKind.CircleOutline:
                     // Creates a normalized vector, then multiply it by the radius
                     return Vector2Helper.FromAngle(random.NextFloat() * MathF.PI * 2) * random.NextFloat() * Circle.Radius + Circle.Center;
 

--- a/src/Murder/Data/GameDataManager_Save.cs
+++ b/src/Murder/Data/GameDataManager_Save.cs
@@ -68,7 +68,11 @@ namespace Murder.Data
         protected SaveData? _activeSaveData;
 
         private GamePreferences? _preferences;
-        public ImmutableArray<Color> CurrentPalette;
+        
+        /// <summary>
+        /// Used by the color picker to allow selecting common colors quicker.
+        /// </summary>
+        public ImmutableArray<Color> CurrentPalette = [];
 
         private bool _loadedSaveFiles = false;
 


### PR DESCRIPTION
This hardens the particle system against some common crashes by:

- Ensuring we're handling all possible emitter shapes.
- Initializing the `CurrentPalette` field so it doesn't crash when we're trying to pick the particle colors.