### PR TITLE
Snap collider to grid while holding ctrl

### DIFF
--- a/src/Murder.Editor/Services/EditorServices.cs
+++ b/src/Murder.Editor/Services/EditorServices.cs
@@ -1,4 +1,5 @@
-﻿using Murder.Core.Geometry;
+﻿using Microsoft.Xna.Framework.Input;
+using Murder.Core.Geometry;
 using Murder.Core.Graphics;
 using Murder.Core.Input;
 using Murder.Services;
@@ -129,6 +130,11 @@ namespace Murder.Editor.Services
                 }
 
                 var target = (cursorPosition + _dragOffset).Point();
+                if (Game.Input.Down(Keys.LeftControl))
+                {
+                    target = target.SnapToGridDelta();
+                }
+                
                 switch (_draggingStyle)
                 {
                     case DragStyle.Move:
@@ -301,6 +307,11 @@ namespace Murder.Editor.Services
             if (_draggingHandle == id)
             {
                 var target = (cursorPosition + _dragOffset).Point();
+                if (Game.Input.Down(Keys.LeftControl))
+                {
+                    target = target.SnapToGridDelta();
+                }
+
                 if (!Game.Input.Down(MurderInputButtons.LeftClick))
                 {
                     _draggingHandle = String.Empty;

--- a/src/Murder.Editor/Services/EditorServices.cs
+++ b/src/Murder.Editor/Services/EditorServices.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Xna.Framework.Input;
-using Murder.Core.Geometry;
+﻿using Murder.Core.Geometry;
 using Murder.Core.Graphics;
 using Murder.Core.Input;
 using Murder.Services;
@@ -130,7 +129,7 @@ namespace Murder.Editor.Services
                 }
 
                 var target = (cursorPosition + _dragOffset).Point();
-                if (Game.Input.Down(Keys.LeftControl))
+                if (Game.Input.Down(InputHelpers.OSActionModifier))
                 {
                     target = target.SnapToGridDelta();
                 }
@@ -307,7 +306,7 @@ namespace Murder.Editor.Services
             if (_draggingHandle == id)
             {
                 var target = (cursorPosition + _dragOffset).Point();
-                if (Game.Input.Down(Keys.LeftControl))
+                if (Game.Input.Down(InputHelpers.OSActionModifier))
                 {
                     target = target.SnapToGridDelta();
                 }

--- a/src/Murder/Utilities/GridHelper.cs
+++ b/src/Murder/Utilities/GridHelper.cs
@@ -95,6 +95,13 @@ namespace Murder.Utilities
                 vector2.Y - vector2.Y % Grid.CellSize);
         }
 
+        public static Point SnapToGridDelta(this Point point)
+        {
+            return new(
+                point.X - point.X % Grid.CellSize,
+                point.Y - point.Y % Grid.CellSize);
+        }
+
         public static IEnumerable<Point> Line(Point start, Point end)
         {
             int x = start.X;


### PR DESCRIPTION
This makes it so that holding control while editing a collider's shape snaps its position and size to the grid.