### PR TITLE
Fix group name of placed prefabs

### DIFF
--- a/src/Murder.Editor/Systems/EntitiesPlacerSystem.cs
+++ b/src/Murder.Editor/Systems/EntitiesPlacerSystem.cs
@@ -170,7 +170,7 @@ namespace Murder.Editor.Systems
                         prefabGuid,
                         [
                             new PositionComponent(cursorWorldPosition),
-                        ], prefab?.Name ?? "Unknown Prefab");
+                        ], targetGroup);
 
                     ImGui.CloseCurrentPopup();
                 }


### PR DESCRIPTION
Currently when adding a prefab via right clicking and choosing "Add a prefab" the created entity gets put in a new group with the same name as the prefab instead of the targeted group.  This fixes that by putting it in the intended group instead. 
The name of the entity will still be the name of the prefab, the third parameter of `hook.AddPrefabWithStage` is only used for the  group.