### PR TITLE
Make time properties protected instead of private.

### DIFF
--- a/src/Murder/Game.cs
+++ b/src/Murder/Game.cs
@@ -334,18 +334,18 @@ namespace Murder
         /* *** Private instance fields *** */
 
         // Update properties.
-        private float _fixedUpdateDelta;
+        protected float _fixedUpdateDelta;
 
-        private double _scaledElapsedTime = 0;
-        private double _unscaledElapsedTime = 0;
-        private double _scaledDeltaTime = 0;
-        private double _unscaledDeltaTime = 0;
+        protected double _scaledElapsedTime = 0;
+        protected double _unscaledElapsedTime = 0;
+        protected double _scaledDeltaTime = 0;
+        protected double _unscaledDeltaTime = 0;
 
-        private double _lastFixedUpdateTime = 0;
-        private double _fixedAccumulatorSeconds = 0;
+        protected double _lastFixedUpdateTime = 0;
+        protected double _fixedAccumulatorSeconds = 0;
 
-        private double _scaledPreviousElapsedTime = 0;
-        private double _unscaledPreviousElapsedTime = 0;
+        protected double _scaledPreviousElapsedTime = 0;
+        protected double _unscaledPreviousElapsedTime = 0;
 
         /// <summary>
         /// This is the underlying implementation of the game. This listens to the murder game events.


### PR DESCRIPTION
Allows headless runners.

Time properties currently depend on being updated through XNA. Changing the time properties to protected allows for a custom Game that can update the time properties (ie. DeltaTime) in other contexts. In particular, running a headless Game for unit tests or for simulation outside of XNA where time needs to be simulated. Actual ticking and changing of time is left for the subclass to handle internally.

Player Impact: None, this an object-oriented change only.

Developer Experience Impact: Allows for subclasses to update the time directly. A footgun if used in the XNA loop; greater customization if used outside XNA.